### PR TITLE
fix: int casting from null node has_thermostat>actual_temperature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build/
 dist/
 *.egg-info/
+.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 build/
 dist/
 *.egg-info/
-.idea/*

--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -267,7 +267,13 @@ class FritzhomeDevice(object):
 
         if self.has_thermostat:
             val = node.getElementsByTagName('hkr')[0]
-            self.actual_temperature = int(get_node_value(val, 'tist')) / 2
+
+            # pass if get_node_value is empty to prevent ValueError exception if device is not responding
+            try:
+                self.actual_temperature = int(get_node_value(val, 'tist')) / 2
+            except ValueError:
+                pass
+
             self.target_temperature = int(get_node_value(val, 'tsoll')) / 2
             self.eco_temperature = int(get_node_value(val, 'absenk')) / 2
             self.comfort_temperature = int(get_node_value(val, 'komfort')) / 2


### PR DESCRIPTION
this fixes an issue when thermostat is not reporting any temperature but is setup in the fritzbox. 
(Battery, Issue)

I was getting a ValueError because the node was empty and it is trying to cast a integer.

```
INFO:pyfritzhome.fritzhome:logout
Traceback (most recent call last):
  File "/usr/local/bin/fritzhome", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/site-packages/pyfritzhome/cli.py", line 163, in main
    args.func(fritzbox, args)
  File "/usr/local/lib/python3.6/site-packages/pyfritzhome/cli.py", line 19, in list_all
    devices = fritz.get_devices()
  File "/usr/local/lib/python3.6/site-packages/pyfritzhome/fritzhome.py", line 135, in get_devices
    device = FritzhomeDevice(self, node=element)
  File "/usr/local/lib/python3.6/site-packages/pyfritzhome/fritzhome.py", line 251, in __init__
    self._update_from_node(node)
  File "/usr/local/lib/python3.6/site-packages/pyfritzhome/fritzhome.py", line 271, in _update_from_node
    self.actual_temperature = int(get_node_value(val, 'tist')) / 2 
ValueError: invalid literal for int() with base 10: '' 
```