### PR TITLE
Handle alert-sensors such as door- and window sensors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,7 @@ Tested Devices
 * `FRITZ!Box 6490 Cable`_ with FRITZ!OS 06.85
 * `FRITZ!DECT 200`_ with firmware 03.87
 * `Comet DECT`_ with firmware 03.54
+* `Panasonic KX-HNS101`
 
 
 fritzhome CLI tool

--- a/pyfritzhome/cli.py
+++ b/pyfritzhome/cli.py
@@ -48,6 +48,9 @@ def list_all(fritz, args):
             print("  target=%s" % device.target_temperature)
             print("  comfort=%s" % device.comfort_temperature)
             print("  eco=%s" % device.eco_temperature)
+        if device.has_alarm:
+            print(" Alert:")
+            print("  alert=%s" % device.alert_state)
 
 
 def device_name(fritz, args):

--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -213,6 +213,10 @@ class Fritzhome(object):
         plain = self._aha_request('gethkrabsenk', ain=ain)
         return (float(plain) - 16) / 2 + 8
 
+    def get_alert_state(self, ain):
+        """Get the alert state."""
+        device = self.get_device_by_ain(ain)
+        return device.alert_state
 
 class FritzhomeDevice(object):
     """The Fritzhome Device class."""
@@ -243,6 +247,7 @@ class FritzhomeDevice(object):
     energy = None
     offset = None
     temperature = None
+    alert_state = None
 
     def __init__(self, fritz=None, node=None):
         if fritz is not None:
@@ -325,6 +330,13 @@ class FritzhomeDevice(object):
             try:
                 self.temperature = int(get_node_value(val, 'celsius')) / 10
             except ValueError:
+                pass
+        
+        if self.has_alarm:
+            val = node.getElementsByTagName('alert')[0]
+            try:
+                self.alert_state = bool(int(get_node_value(val, 'state')))
+            except IndexError:
                 pass
 
     def __repr__(self):

--- a/tests/elements.py
+++ b/tests/elements.py
@@ -53,6 +53,19 @@ device_list_xml = """<devicelist version="1">
             </nextchange>
         </hkr>
     </device>
+    <device functionbitmask="8208" fwversion="0.0" id="2000" 
+     identifier="05333 0077045-1" manufacturer="0x0512" productname="HAN-FUN">
+        <present>1</present>
+        <name>Fenster</name>
+        <etsiunitinfo>
+            <etsideviceid>406</etsideviceid>
+            <unittype>514</unittype>
+            <interfaces>256</interfaces>
+        </etsiunitinfo>
+        <alert>
+            <state>1</state>
+        </alert>
+    </device>
     <group identifier="65:3A:18-900" id="900" functionbitmask="512" fwversion="1.0" manufacturer="AVM" productname="">
         <present>1</present>
         <name>Gruppe</name>
@@ -235,4 +248,41 @@ device_hkr_no_temp_values_xml= """<device functionbitmask="320" fwversion="03.54
 			<tchange>36</tchange>
 		</nextchange>
 	</hkr>
+</device>"""
+
+device_alert_on_xml = """<device functionbitmask="8208" fwversion="0.0" id="2000" identifier="05333 0077045-1" manufacturer="0x0512" productname="HAN-FUN">
+    <present>1</present>
+    <name>Fenster</name>
+    <etsiunitinfo>
+        <etsideviceid>406</etsideviceid>
+        <unittype>514</unittype>
+        <interfaces>256</interfaces>
+    </etsiunitinfo>
+    <alert>
+        <state>1</state>
+    </alert>
+</device>"""
+
+device_alert_off_xml = """<device functionbitmask="8208" fwversion="0.0" id="2000" identifier="05333 0077045-2" manufacturer="0x0512" productname="HAN-FUN">
+    <present>1</present>
+    <name>Fenster</name>
+    <etsiunitinfo>
+        <etsideviceid>406</etsideviceid>
+        <unittype>514</unittype>
+        <interfaces>256</interfaces>
+    </etsiunitinfo>
+    <alert>
+        <state>0</state>
+    </alert>
+</device>"""
+
+device_alert_no_alertstate_xml = """<device functionbitmask="8208" fwversion="0.0" id="2000" identifier="05333 0077045-3" manufacturer="0x0512" productname="HAN-FUN">
+    <present>1</present>
+    <name>Fenster</name>
+    <etsiunitinfo>
+        <etsideviceid>406</etsideviceid>
+        <unittype>514</unittype>
+        <interfaces>256</interfaces>
+    </etsiunitinfo>
+    <alert></alert>
 </device>"""

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -9,7 +9,8 @@ from .elements import (device_list_xml, device_list_battery_ok_xml,
                        device_list_battery_low_xml, device_not_present_xml,
                        device_no_devicelock_element_xml,
                        device_hkr_fw_03_50_xml, device_hkr_fw_03_54_xml,
-                       device_hkr_no_temp_values_xml)
+                       device_hkr_no_temp_values_xml, device_alert_on_xml,
+                       device_alert_off_xml, device_alert_no_alertstate_xml)
 
 
 def get_switch_test_device():
@@ -104,6 +105,52 @@ class TestDevice(object):
 
         eq_(device.ain, '23456')
         assert_true(device.present)
+
+    def test_device_alert_on(self):
+        mock = MagicMock()
+        mock.side_effect = [
+            device_alert_on_xml,
+        ]
+
+        fritz = Fritzhome('10.0.0.1', 'user', 'pass')
+        fritz._request = mock
+        element = fritz.get_device_element('05333 0077045-1')
+        device = FritzhomeDevice(node=element)
+
+        eq_(device.ain, '05333 0077045-1')
+        assert_true(device.present)
+        eq_(device.alert_state, True)
+
+    def test_device_alert_off(self):
+        mock = MagicMock()
+        mock.side_effect = [
+            device_alert_off_xml,
+        ]
+
+        fritz = Fritzhome('10.0.0.1', 'user', 'pass')
+        fritz._request = mock
+        element = fritz.get_device_element('05333 0077045-2')
+        device = FritzhomeDevice(node=element)
+
+        eq_(device.ain, '05333 0077045-2')
+        assert_true(device.present)
+        eq_(device.alert_state, False)
+
+    def test_device_alert_no_alertstate(self):
+        mock = MagicMock()
+        mock.side_effect = [
+            device_alert_no_alertstate_xml,
+        ]
+
+        fritz = Fritzhome('10.0.0.1', 'user', 'pass')
+        fritz._request = mock
+        element = fritz.get_device_element('05333 0077045-3')
+        device = FritzhomeDevice(node=element)
+
+        eq_(device.ain, '05333 0077045-3')
+        assert_true(device.present)
+        eq_(device.alert_state, None)
+
 
     def test_device_update(self):
         mock = MagicMock()

--- a/tests/test_fritzhome.py
+++ b/tests/test_fritzhome.py
@@ -162,3 +162,14 @@ class TestFritzhome(object):
         fritz._request.assert_called_with(
             'http://10.0.0.1/webservices/homeautoswitch.lua',
             {'sid': None, 'ain': '1', 'switchcmd': 'sethkrtsoll', 'param': 254})
+
+    def test_get_alert_state(self):
+        mock = MagicMock()
+        mock.side_effect = [
+            device_list_xml,
+        ]
+
+        fritz = Fritzhome('10.0.0.1', 'user', 'pass')
+        fritz._request = mock
+
+        eq_(fritz.get_alert_state('05333 0077045-1'), True)


### PR DESCRIPTION
The alert state is, as far as I can tell, only transmitted in the
devicelist, not through an explicit endpoint.