### PR TITLE
Ignore empty state in switch device

### DIFF
--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -394,7 +394,7 @@ class FritzhomeDevice(object):
         val = node.getElementsByTagName('alert')[0]
         try:
             self.alert_state = bool(int(get_node_value(val, 'state')))
-        except IndexError:
+        except(IndexError, ValueError):
             pass
 
     def __repr__(self):

--- a/tests/elements.py
+++ b/tests/elements.py
@@ -431,3 +431,19 @@ device_hkr_fritzos_7_xml = """<?xml version="1.0" ?>
         </hkr>
     </device>
 </devicelist>"""
+
+device_magenta_smoke_alarm_xml = """<?xml version="1.0" ?>
+<devicelist version="1">
+    <device functionbitmask="8208" fwversion="0.0" id="2000" identifier="11324 0244498-1" manufacturer="0x2c3c" productname="HAN-FUN">
+        <present>1</present>
+        <name>Rauchmelder</name>
+        <etsiunitinfo>
+            <etsideviceid>406</etsideviceid>
+            <unittype>516</unittype>
+            <interfaces>256</interfaces>
+        </etsiunitinfo>
+        <alert>
+            <state/>
+        </alert>
+    </device>
+</devicelist>"""

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -15,7 +15,8 @@ from .elements import (device_list_xml, device_list_battery_ok_xml,
                        device_alert_off_xml, device_alert_no_alertstate_xml,
                        device_hkr_state_on_xml, device_hkr_state_off_xml,
                        device_hkr_state_eco_xml, device_hkr_state_comfort_xml,
-                       device_hkr_state_manual_xml, device_hkr_fritzos_7_xml)
+                       device_hkr_state_manual_xml, device_hkr_fritzos_7_xml,
+                       device_magenta_smoke_alarm_xml)
 
 
 def get_switch_test_device():
@@ -395,3 +396,11 @@ class TestDevice(object):
 
         device = self.fritz.get_device_by_ain('12345')
         eq_(device.holiday_active, False)
+
+    def test_magenta_smoke_alarm(self):
+        self.mock.side_effect = [
+            device_magenta_smoke_alarm_xml,
+        ]
+        device = self.fritz.get_device_by_ain('11324 0244498-1')
+        assert_true(device.present)
+        eq_(device.alert_state, None)


### PR DESCRIPTION
Magenta SmartHome smoke alarm returns empty state, causing integer conversion to fail.
Catch ValueError according to valid switch states in 'AVM HTTP interface' doc.