### PR TITLE
HTTPS support

### DIFF
--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -52,7 +52,7 @@ class Fritzhome(object):
 
     def _login_request(self, username=None, secret=None):
         """Send a login request with paramerters."""
-        url = self.get_prefixed_url(self._host) + '/login_sid.lua'
+        url = self.get_prefixed_host() + '/login_sid.lua'
         params = {}
         if username:
             params['username'] = username
@@ -70,7 +70,7 @@ class Fritzhome(object):
     def _logout_request(self):
         """Send a logout request."""
         _LOGGER.debug('logout')
-        url = self.get_prefixed_url(self._host) + '/login_sid.lua'
+        url = self.get_prefixed_host() + '/login_sid.lua'
         params = {
             'security:command/logout': '1',
             'sid': self._sid
@@ -87,8 +87,7 @@ class Fritzhome(object):
 
     def _aha_request(self, cmd, ain=None, param=None, rf=str):
         """Send an AHA request."""
-        path = '/webservices/homeautoswitch.lua'
-        url = self.get_prefixed_url(self._host) + path
+        url = self.get_prefixed_host() + '/webservices/homeautoswitch.lua'
         params = {
             'switchcmd': cmd,
             'sid': self._sid
@@ -126,14 +125,14 @@ class Fritzhome(object):
         self._logout_request()
         self._sid = None
 
-    def get_prefixed_url(self, host):
-        """Choose the correct protocol prefix for the host. 
+    def get_prefixed_host(self):
+        """Choose the correct protocol prefix for the host.
         Supports three input formats:
-        - https://<host> (requests use strict certificate validation by default)
+        - https://<host>(requests use strict certificate validation by default)
         - http://<host> (unecrypted)
         - <host> (unencrypted)
         """
-        protocol_url = host
+        host = self._host
         if host.startswith('https://') or host.startswith('http://'):
             return host
         else:

--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -52,7 +52,7 @@ class Fritzhome(object):
 
     def _login_request(self, username=None, secret=None):
         """Send a login request with paramerters."""
-        url = 'http://' + self._host + '/login_sid.lua'
+        url = self.get_prefixed_url(self._host) + '/login_sid.lua'
         params = {}
         if username:
             params['username'] = username
@@ -70,7 +70,7 @@ class Fritzhome(object):
     def _logout_request(self):
         """Send a logout request."""
         _LOGGER.debug('logout')
-        url = 'http://' + self._host + '/login_sid.lua'
+        url = self.get_prefixed_url(self._host) + '/login_sid.lua'
         params = {
             'security:command/logout': '1',
             'sid': self._sid
@@ -87,7 +87,7 @@ class Fritzhome(object):
 
     def _aha_request(self, cmd, ain=None, param=None, rf=str):
         """Send an AHA request."""
-        url = 'http://' + self._host + '/webservices/homeautoswitch.lua'
+        url = self.get_prefixed_url(self._host) + '/webservices/homeautoswitch.lua'
         params = {
             'switchcmd': cmd,
             'sid': self._sid
@@ -124,6 +124,19 @@ class Fritzhome(object):
         """Logout."""
         self._logout_request()
         self._sid = None
+
+    def get_prefixed_url(self, host):
+        """Choose the correct protocol prefix for the host. 
+        Supports three input formats:
+        - https://<host> (requests use strict certificate validation by default)
+        - http://<host> (unecrypted)
+        - <host> (unencrypted)
+        """
+        protocol_url = host
+        if host.startswith('https://') or host.startswith('http://'):
+            return host
+        else:
+            return 'http://' + host
 
     def get_device_elements(self):
         """Get the DOM elements for the device list."""

--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -87,7 +87,8 @@ class Fritzhome(object):
 
     def _aha_request(self, cmd, ain=None, param=None, rf=str):
         """Send an AHA request."""
-        url = self.get_prefixed_url(self._host) + '/webservices/homeautoswitch.lua'
+        path = '/webservices/homeautoswitch.lua'
+        url = self.get_prefixed_url(self._host) + path
         params = {
             'switchcmd': cmd,
             'sid': self._sid


### PR DESCRIPTION
About 14days ago i opened an issue:
[Link](https://github.com/hthiery/python-fritzhome/issues/18)

This includes the fix according to the issue.
It enables the support of https to communicate with the fritzbox over the internet.
It is fully backward compatible.