### PR TITLE
Exclude tests from installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     long_description=readme,
     author="Heiko Thiery",
     author_email="heiko.thiery@gmail.com",
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests*",)),
     url="http://github.com/hthiery/python-fritzhome",
     license="LGPLv2+",
     classifiers=[


### PR DESCRIPTION
Generally not desirable in the first place, but especially not in the global top level `tests` package.