### PR TITLE
Raise runtime error instead of becoming disfunctional on missing login

### DIFF
--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -118,6 +118,8 @@ class Fritzhome(object):
 
     def update_devices(self):
         _LOGGER.info("Updating Devices ...")
+        if self._sid is None:
+            raise RuntimeError("Please login before accessing devices")
         if self._devices is None:
             self._devices = {}
 


### PR DESCRIPTION
When we forget to log into the Fritz!Box, the code cannot recover without intimate knowledge of the code.

Example for a fail on current `master`:
``` python
>>> from pyfritzhome import Fritzhome                                                                                                                                                                              
>>> f = Fritzhome("fritz.box", "someuser", "somepass")                                                                                                                                     
>>> f._devices
# Just to see it is None here
>>> f.get_devices()                                                                                                                                                                                                
Traceback (most recent call last):                                                                                                                                                                                 
  File "<stdin>", line 1, in <module>                                                                                                                                                                              
  File "/home/me/FritzBox/python-fritzhome/pyfritzhome/fritzhome.py", line 153, in get_devices                                                                                                                 
    return list(self.get_devices_as_dict().values())                                                                                                                                                               
  File "/home/me/FritzBox/python-fritzhome/pyfritzhome/fritzhome.py", line 158, in get_devices_as_dict                                                                                                         
    self.update_devices()                                                                                                                                                                                          
  File "/home/me/FritzBox/python-fritzhome/pyfritzhome/fritzhome.py", line 124, in update_devices                                                                                                              
    for element in self.get_device_elements():                                                                                                                                                                     
  File "/home/me/FritzBox/python-fritzhome/pyfritzhome/fritzhome.py", line 138, in get_device_elements                                                                                                         
    plain = self._aha_request("getdevicelistinfos")                                                                                                                                                                
  File "/home/me/FritzBox/python-fritzhome/pyfritzhome/fritzhome.py", line 77, in _aha_request                                                                                                                 
    plain = self._request(url, params)                                                                                                                                                                             
  File "/home/me/FritzBox/python-fritzhome/pyfritzhome/fritzhome.py", line 34, in _request                                                                                                                     
    rsp.raise_for_status()                                                                                                                                                                                         
  File "/usr/lib/python3/dist-packages/requests/models.py", line 940, in raise_for_status                                                                                                                          
    raise HTTPError(http_error_msg, response=self)                                                                                                                                                                 
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: http://192.168.2.1/webservices/homeautoswitch.lua?switchcmd=getdevicelistinfos
>>> f._devices                                                                                                                                                                                                     
{}
# Note that the internal variable is not None here any more
```
The code fails to recover from this as even when we realize we should have logged in:
``` python
>>> f.get_devices()
[]
>>> f.login()
>>> f.get_devices()
[]
```
Only with knowing it needs to be `None`, we can succeed here (after a login!):
``` python
>>> f._devices = None
>>> f.get_devices()
[12345 12345678 26 AVM FRITZ!DECT 301 Küche, ...]
``` 

---

This PR changes this by catching the error before it happens. This is implemented by throwing a proper `RunTimeException` when we try to update devices without a login happening before (or if there was a logout in between):
``` python
#### This is a new session with the code from my branch
>>> from pyfritzhome import Fritzhome                                                                                                                                                                              
>>> f = Fritzhome("fritz.box", "someuser", "somepass")                                                  
>>> f.get_devices()                                           
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>                                                                    
  File "/home/me/FritzBox/python-fritzhome/pyfritzhome/fritzhome.py", line 156, in get_devices                                                                                                                 
    return list(self.get_devices_as_dict().values())                                                                                                                                                               
  File "/home/me/FritzBox/python-fritzhome/pyfritzhome/fritzhome.py", line 161, in get_devices_as_dict
    self.update_devices()         
  File "/home/me/FritzBox/python-fritzhome/pyfritzhome/fritzhome.py", line 122, in update_devices
    raise RuntimeError("Please log into your Fritz!Box")                                          
RuntimeError: Please log into your Fritz!Box                                               
>>> f.get_devices()                                           
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>                                                                    
  File "/home/me/FritzBox/python-fritzhome/pyfritzhome/fritzhome.py", line 156, in get_devices                                                                                                                 
    return list(self.get_devices_as_dict().values())                                                                                                                                                               
  File "/home/me/FritzBox/python-fritzhome/pyfritzhome/fritzhome.py", line 161, in get_devices_as_dict
    self.update_devices()         
  File "/home/me/FritzBox/python-fritzhome/pyfritzhome/fritzhome.py", line 122, in update_devices
    raise RuntimeError("Please log into your Fritz!Box")                                          
RuntimeError: Please log into your Fritz!Box  
```
This can be repeated as often as the user likes and succeeds after a login without any further manual intervention of the user:
``` python
>>> f.login()
>>> f.get_devices()
[12345 12345678 26 AVM FRITZ!DECT 301 Küche, ...]
```