### PR TITLE
Add support for relative humidity as reported by Fritz!DECT400 with firmware 05.10

### DIFF
--- a/pyfritzhome/devicetypes/fritzhomedevicetemperature.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicetemperature.py
@@ -13,6 +13,7 @@ class FritzhomeDeviceTemperature(FritzhomeDeviceBase):
 
     offset = None
     temperature = None
+    rel_humidity = None
 
     def _update_from_node(self, node):
         super()._update_from_node(node)
@@ -43,3 +44,11 @@ class FritzhomeDeviceTemperature(FritzhomeDeviceBase):
             )
         except ValueError:
             pass
+
+        humidity_element = node.find("humidity")
+        if humidity_element is not None:
+            try:
+                self.rel_humidity = self.get_node_value_as_int(humidity_element,
+                                                               "rel_humidity")
+            except ValueError:
+                pass

--- a/tests/responses/button/device_button_fritzdect440_fw_05_10.xml
+++ b/tests/responses/button/device_button_fritzdect440_fw_05_10.xml
@@ -1,0 +1,32 @@
+<devicelist version="1" fwversion="7.21">
+	<device identifier="12345 0000002" id="30" functionbitmask="1048864" fwversion="05.10" manufacturer="AVM" productname="FRITZ!DECT 440">
+		<present>1</present>
+		<txbusy>0</txbusy>
+		<name>Taster Wohnzimmer</name>
+		<battery>100</battery>
+		<batterylow>0</batterylow>
+		<temperature>
+			<celsius>215</celsius>
+			<offset>0</offset>
+		</temperature>
+		<humidity>
+			<rel_humidity>44</rel_humidity>
+		</humidity>
+		<button identifier="12345 0000002-1" id="5004">
+			<name>Taster Wohnzimmer: Oben rechts</name>
+			<lastpressedtimestamp>1609594202</lastpressedtimestamp>
+		</button>
+		<button identifier="12345 0000002-3" id="5005">
+			<name>Taster Wohnzimmer: Unten rechts</name>
+			<lastpressedtimestamp></lastpressedtimestamp>
+		</button>
+		<button identifier="12345 0000002-5" id="5006">
+			<name>Taster Wohnzimmer: Unten links</name>
+			<lastpressedtimestamp></lastpressedtimestamp>
+		</button>
+		<button identifier="12345 0000002-7" id="5007">
+			<name>Taster Wohnzimmer: Oben links</name>
+			<lastpressedtimestamp>1609603776</lastpressedtimestamp>
+		</button>
+	</device>
+</devicelist>

--- a/tests/test_fritzhomedevicebutton.py
+++ b/tests/test_fritzhomedevicebutton.py
@@ -37,3 +37,13 @@ class TestFritzhomeDeviceButton(object):
         button = device.get_button_by_ain("12345 0000001-2")
         eq_(button.name, "Taster Wohnzimmer: Unten rechts")
         eq_(button.last_pressed, 1608557682)
+
+    def test_button_fritzdect440_humidity(self):
+        self.mock.side_effect = [
+            Helper.response("button/device_button_fritzdect440_fw_05_10"),
+        ]
+
+        self.fritz.update_devices()
+        device = self.fritz.get_device_by_ain("12345 0000002")
+        assert_true(device.present)
+        eq_(device.rel_humidity, 44)


### PR DESCRIPTION
If the Fritz!DECT 400 button has the most recent firmware, it may transmit the measured relative humidity. I have two of these buttons (both up-to-date fw) but only one reports the humidity to the Fritz!Box (both show the value on their displays).

The humidity cannot be queried directly, it is still filled from the information available during `update_from_node`.

Example:
``` python
from pyfritzhome import Fritzhome
f = Fritzhome("192.168.1.1", "fritz_smarthome", 'password')
f.login()
device=f.get_device_by_ain("13011 0003111") # substitute your own AIN
device.rel_humidity
# 46
```