### PR TITLE
Add color temperature mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 build/
 dist/
 *.egg-info/
+.vscode/
 
 # Coverage Information
 .coverage

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 build/
 dist/
 *.egg-info/
-.vscode/
 
 # Coverage Information
 .coverage

--- a/pyfritzhome/devicetypes/fritzhomedevicelightbulb.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicelightbulb.py
@@ -15,6 +15,9 @@ class FritzhomeDeviceLightBulb(FritzhomeDeviceBase):
     level = None
     hue = None
     saturation = None
+    color_temp = None
+    color_mode = None
+    supported_color_mode = None
 
     def _update_from_node(self, node):
         super()._update_from_node(node)
@@ -48,10 +51,25 @@ class FritzhomeDeviceLightBulb(FritzhomeDeviceBase):
 
         colorcontrol_element = node.find("colorcontrol")
         try:
+            self.color_mode = colorcontrol_element.attrib.get("current_mode")
+
+            self.supported_color_mode = colorcontrol_element.attrib.get("supported_modes")
+
+        except ValueError:
+            pass
+
+        try:
             self.hue = self.get_node_value_as_int(colorcontrol_element, "hue")
 
             self.saturation = self.get_node_value_as_int(colorcontrol_element,
                                                          "saturation")
+
+        except ValueError:
+            pass
+
+        try:
+            self.color_temp = self.get_node_value_as_int(colorcontrol_element,
+                                                         "temperature")
 
         except ValueError:
             pass

--- a/pyfritzhome/devicetypes/fritzhomedevicelightbulb.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicelightbulb.py
@@ -53,7 +53,8 @@ class FritzhomeDeviceLightBulb(FritzhomeDeviceBase):
         try:
             self.color_mode = colorcontrol_element.attrib.get("current_mode")
 
-            self.supported_color_mode = colorcontrol_element.attrib.get("supported_modes")
+            self.supported_color_mode = colorcontrol_element.attrib.get(
+                "supported_modes")
 
         except ValueError:
             pass

--- a/pyfritzhome/devicetypes/fritzhomedevicelightbulb.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicelightbulb.py
@@ -66,14 +66,17 @@ class FritzhomeDeviceLightBulb(FritzhomeDeviceBase):
                                                          "saturation")
 
         except ValueError:
-            pass
+            # reset values after color mode changed
+            self.hue = None
+            self.saturation = None
 
         try:
             self.color_temp = self.get_node_value_as_int(colorcontrol_element,
                                                          "temperature")
 
         except ValueError:
-            pass
+            # reset values after color mode changed
+            self.color_temp = None
 
     def set_state_off(self):
         """ Switch light bulb off """

--- a/tests/responses/lightbulb/device_FritzDECT500_34_12_16_color_temp_mode.xml
+++ b/tests/responses/lightbulb/device_FritzDECT500_34_12_16_color_temp_mode.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<devicelist version="1">
+	<device identifier="12345" id="407" functionbitmask="1" fwversion="34.10.16.16.009" manufacturer="AVM" productname="FRITZ!DECT 500">
+		<present>
+			1
+		</present>
+		<txbusy>
+			0
+		</txbusy>
+		<name>
+			FRITZ!DECT 500 Büro
+		</name>
+	</device>
+	<device identifier="12345-1" id="2001" functionbitmask="237572" fwversion="0.0" manufacturer="AVM" productname="FRITZ!DECT 500">
+		<present>
+			1
+		</present>
+		<txbusy>
+			0
+		</txbusy>
+		<name>
+			FRITZ!DECT 500 Büro
+		</name>
+		<simpleonoff>
+			<state>
+				1
+			</state>
+		</simpleonoff>
+		<levelcontrol>
+			<level>
+				3
+			</level>
+			<levelpercentage>
+				1
+			</levelpercentage>
+		</levelcontrol>
+		<colorcontrol supported_modes="5" current_mode="4" fullcolorsupport="1" mapped="1">
+			<hue>
+			</hue>
+			<saturation>
+			</saturation>
+			<unmapped_hue>
+				0
+			</unmapped_hue>
+			<unmapped_saturation>
+				255
+			</unmapped_saturation>
+			<temperature>
+				2800
+			</temperature>
+		</colorcontrol>
+		<etsiunitinfo>
+			<etsideviceid>
+				407
+			</etsideviceid>
+			<unittype>
+				278
+			</unittype>
+			<interfaces>
+				512,514,513
+			</interfaces>
+		</etsiunitinfo>
+	</device>
+</devicelist>

--- a/tests/test_fritzhomedevicelightbulb.py
+++ b/tests/test_fritzhomedevicelightbulb.py
@@ -31,7 +31,36 @@ class TestFritzhomeDeviceLightBulb(object):
         device = self.fritz.get_device_by_ain("12345-1")
         assert_true(device.has_lightbulb)
         assert_true(device.state)  # Lightbulb is switched on
+        eq_(device.color_mode, "1")
+        eq_(device.supported_color_mode, "5")
+        eq_(device.hue, 358)
+        eq_(device.saturation, 180)
+        eq_(device.color_temp, None)
         eq_(device.name, u"FRITZ!DECT 500 Büro")
+
+    def test_device_init_color_temp_mode(self):
+        self.mock.side_effect = [
+            Helper.response("lightbulb/device_FritzDECT500_34_12_16_color_temp_mode")
+        ]
+
+        self.fritz.update_devices()
+        device = self.fritz.get_device_by_ain("12345")
+
+        eq_(device.ain, "12345")
+        eq_(device.fw_version, "34.10.16.16.009")
+        assert_true(device.present)  # Lightbulb has power and is connected
+
+        # Get sub-device
+        device = self.fritz.get_device_by_ain("12345-1")
+        assert_true(device.has_lightbulb)
+        assert_true(device.state)  # Lightbulb is switched on
+        eq_(device.color_mode, "4")
+        eq_(device.supported_color_mode, "5")
+        eq_(device.hue, None)
+        eq_(device.saturation, None)
+        eq_(device.color_temp, 2800)
+        eq_(device.name, u"FRITZ!DECT 500 Büro")
+
 
     def test_get_colors(self):
         self.mock.side_effect = [


### PR DESCRIPTION
Hi @hthiery 
based on the API documentation*, I have added the color temperature mode, since it is also supported by HA (_and those is needed for #47_).
`device_FritzDECT500_34_12_16_color_temp_mode.xml` is created based on assumptions from API docs*
Maybe you could verify `device_FritzDECT500_34_12_16_color_temp_mode.xml` by setting your Fritz!DECT 500 into color temperature mode and compare the results :thinking: 

---
\* _Page 11: https://avm.de/fileadmin/user_upload/Global/Service/Schnittstellen/AHA-HTTP-Interface.pdf_