### PR TITLE
Add support for templates to library and CLI.

### DIFF
--- a/pyfritzhome/cli.py
+++ b/pyfritzhome/cli.py
@@ -103,6 +103,37 @@ def switch_toggle(fritz, args):
     fritz.set_switch_state_toggle(args.ain)
 
 
+def list_templates(fritz, args):
+    """Command that prints all template information."""
+    templates = fritz.get_templates()
+    devices = fritz.get_devices_as_dict()
+
+    for template in templates:
+        print("#" * 30)
+        print("name=%s" % template.name)
+        print("  ain=%s" % template.ain)
+
+        print(" Apply:")
+        print("  hkr_summer=%s" % template.apply_hkr_summer)
+        print("  hkr_temperature=%s" % template.apply_hkr_temperature)
+        print("  hkr_holidays=%s" % template.apply_hkr_holidays)
+        print("  hkr_time_table=%s" % template.apply_hkr_time_table)
+        print("  relay_manual=%s" % template.apply_relay_manual)
+        print("  relay_automatic=%s" % template.apply_relay_automatic)
+        print("  level=%s" % template.apply_level)
+        print("  color=%s" % template.apply_color)
+        print("  dialhelper=%s" % template.apply_dialhelper)
+
+        print(" Devices:")
+        for device_id in template.devices:
+            print("  %s=%s" % (device_id, devices[device_id].name))
+
+
+def template_apply(fritz, args):
+    """Command that applies a template."""
+    fritz.apply_template(args.ain)
+
+
 def main(args=None):
     """The main function."""
     parser = argparse.ArgumentParser(description="Fritz!Box Smarthome CLI tool.")
@@ -124,7 +155,7 @@ def main(args=None):
         "--ain",
         type=str,
         dest="ain",
-        help="Actor Identification",
+        help="Actor/Template Identification",
         default=None,
     )
     parser.add_argument(
@@ -183,6 +214,18 @@ def main(args=None):
     subparser = _sub_switch.add_parser("toggle", help="set off state")
     subparser.add_argument("ain", type=str, metavar="AIN", help="Actor Identification")
     subparser.set_defaults(func=switch_toggle)
+
+    # templates
+    subparser = _sub.add_parser("template", help="Template commands")
+    _sub_switch = subparser.add_subparsers()
+
+    # list templates
+    subparser = _sub_switch.add_parser("list", help="List all available templates")
+    subparser.set_defaults(func=list_templates)
+
+    # apply templates
+    subparser = _sub_switch.add_parser("apply", help="Apply template")
+    subparser.set_defaults(func=template_apply)
 
     args = parser.parse_args(args)
 

--- a/pyfritzhome/devicetypes/__init__.py
+++ b/pyfritzhome/devicetypes/__init__.py
@@ -6,6 +6,7 @@ from .fritzhomedeviceswitch import FritzhomeDeviceSwitch
 from .fritzhomedevicetemperature import FritzhomeDeviceTemperature
 from .fritzhomedevicethermostat import FritzhomeDeviceThermostat
 from .fritzhomedevicelightbulb import FritzhomeDeviceLightBulb
+from .fritzhometemplate import FritzhomeTemplate
 
 __all__ = (
     "FritzhomeDeviceAlarm",
@@ -16,4 +17,5 @@ __all__ = (
     "FritzhomeDeviceTemperature",
     "FritzhomeDeviceThermostat",
     "FritzhomeDeviceLightBulb",
+    "FritzhomeTemplate",
 )

--- a/pyfritzhome/devicetypes/fritzhomedevicebase.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicebase.py
@@ -1,33 +1,23 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function
-from abc import ABC
 
 
 import logging
-from xml.etree import ElementTree
-from .fritzhomedevicefeatures import FritzhomeDeviceFeatures
+
+from pyfritzhome.devicetypes.fritzhomeentitybase import FritzhomeEntityBase
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class FritzhomeDeviceBase(ABC):
+class FritzhomeDeviceBase(FritzhomeEntityBase):
     """The Fritzhome Device class."""
 
-    _fritz = None
-    ain: str = None
     identifier = None
     fw_version = None
     manufacturer = None
     productname = None
-    _functionsbitmask = None
     present = None
-
-    def __init__(self, fritz=None, node=None):
-        if fritz is not None:
-            self._fritz = fritz
-        if node is not None:
-            self._update_from_node(node)
 
     def __repr__(self):
         """Return a string."""
@@ -43,36 +33,17 @@ class FritzhomeDeviceBase(ABC):
         """Update the device values."""
         self._fritz.update_devices()
 
-    def _has_feature(self, feature: FritzhomeDeviceFeatures) -> bool:
-        return feature in FritzhomeDeviceFeatures(self._functionsbitmask)
-
     def _update_from_node(self, node):
-        _LOGGER.debug(ElementTree.tostring(node))
+        super()._update_from_node(node)
         self.ain = node.attrib["identifier"]
         self.identifier = node.attrib["id"]
-        self._functionsbitmask = int(node.attrib["functionbitmask"])
         self.fw_version = node.attrib["fwversion"]
         self.manufacturer = node.attrib["manufacturer"]
         self.productname = node.attrib["productname"]
 
-        self.name = node.findtext("name").strip()
         self.present = bool(int(node.findtext("present")))
 
     # General
     def get_present(self):
         """Check if the device is present."""
         return self._fritz.get_device_present(self.ain)
-
-    # XML Helpers
-
-    def get_node_value(self, elem, node):
-        return elem.findtext(node)
-
-    def get_node_value_as_int(self, elem, node) -> int:
-        return int(self.get_node_value(elem, node))
-
-    def get_node_value_as_int_as_bool(self, elem, node) -> bool:
-        return bool(self.get_node_value_as_int(elem, node))
-
-    def get_temp_from_node(self, elem, node):
-        return float(self.get_node_value(elem, node)) / 2

--- a/pyfritzhome/devicetypes/fritzhomeentitybase.py
+++ b/pyfritzhome/devicetypes/fritzhomeentitybase.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+from abc import ABC
+
+
+import logging
+from xml.etree import ElementTree
+from .fritzhomedevicefeatures import FritzhomeDeviceFeatures
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class FritzhomeEntityBase(ABC):
+    """The Fritzhome Entity class."""
+
+    _fritz = None
+    ain: str = None
+    _functionsbitmask = None
+
+    def __init__(self, fritz=None, node=None):
+        if fritz is not None:
+            self._fritz = fritz
+        if node is not None:
+            self._update_from_node(node)
+
+    def __repr__(self):
+        """Return a string."""
+        return "{ain} {name}".format(
+            ain=self.ain,
+            name=self.name,
+        )
+
+    def _has_feature(self, feature: FritzhomeDeviceFeatures) -> bool:
+        return feature in FritzhomeDeviceFeatures(self._functionsbitmask)
+
+    def _update_from_node(self, node):
+        _LOGGER.debug(ElementTree.tostring(node))
+        self.ain = node.attrib["identifier"]
+        self._functionsbitmask = int(node.attrib["functionbitmask"])
+
+        self.name = node.findtext("name").strip()
+
+    # XML Helpers
+
+    def get_node_value(self, elem, node):
+        return elem.findtext(node)
+
+    def get_node_value_as_int(self, elem, node) -> int:
+        return int(self.get_node_value(elem, node))
+
+    def get_node_value_as_int_as_bool(self, elem, node) -> bool:
+        return bool(self.get_node_value_as_int(elem, node))
+
+    def get_temp_from_node(self, elem, node):
+        return float(self.get_node_value(elem, node)) / 2

--- a/pyfritzhome/devicetypes/fritzhometemplate.py
+++ b/pyfritzhome/devicetypes/fritzhometemplate.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+import logging
+
+from .fritzhomeentitybase import FritzhomeEntityBase
+from .fritzhomedevicefeatures import FritzhomeDeviceFeatures
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class FritzhomeTemplate(FritzhomeEntityBase):
+    """The Fritzhome Template class."""
+
+    devices = None
+    features = None
+    apply_hkr_summer = None
+    apply_hkr_temperature = None
+    apply_hkr_holidays = None
+    apply_hkr_time_table = None
+    apply_relay_manual = None
+    apply_relay_automatic = None
+    apply_level = None
+    apply_color = None
+    apply_dialhelper = None
+
+    def _update_from_node(self, node):
+        super()._update_from_node(node)
+
+        self.features = FritzhomeDeviceFeatures(self._functionsbitmask)
+
+        applymask = node.find("applymask")
+        self.apply_hkr_summer = applymask.find("hkr_summer") is not None
+        self.apply_hkr_temperature = applymask.find("hkr_temperature") is not None
+        self.apply_hkr_holidays = applymask.find("hkr_holidays") is not None
+        self.apply_hkr_time_table = applymask.find("hkr_time_table") is not None
+        self.apply_relay_manual = applymask.find("relay_manual") is not None
+        self.apply_relay_automatic = applymask.find("relay_automatic") is not None
+        self.apply_level = applymask.find("level") is not None
+        self.apply_color = applymask.find("color") is not None
+        self.apply_dialhelper = applymask.find("dialhelper") is not None
+
+        self.devices = []
+        for device in node.find("devices").findall("device"):
+            self.devices.append(device.attrib["identifier"])

--- a/pyfritzhome/fritzhomedevice.py
+++ b/pyfritzhome/fritzhomedevice.py
@@ -9,6 +9,7 @@ from .devicetypes import (
     FritzhomeDeviceTemperature,
     FritzhomeDeviceThermostat,
     FritzhomeDeviceLightBulb,
+    FritzhomeTemplate,
 )
 
 

--- a/tests/responses/templates/template_list.xml
+++ b/tests/responses/templates/template_list.xml
@@ -1,0 +1,92 @@
+<templatelist version="1">
+    <!-- Base Data Tests -->
+    <template identifier="tmp0B32F7-1B0650682" id="60000" functionbitmask="320" applymask="0">
+        <name>Base Data</name>
+        <devices />
+        <applymask />
+    </template>
+
+    <!-- Device Tests -->
+    <template identifier="tmp0B32F7-1B0650234" id="60010" functionbitmask="0" applymask="0">
+        <name>One Device</name>
+        <devices>
+            <device identifier="08735 0525249" />
+        </devices>
+        <applymask />
+    </template>
+    <template identifier="tmp0B32F7-1C40A2B8A" id="60011" functionbitmask="0" applymask="0">
+        <name>Multiple Devices</name>
+        <devices>
+            <device identifier="08735 0316335" />
+            <device identifier="08735 0525249" />
+            <device identifier="08735 0526125" />
+            <device identifier="08735 0340143" />
+        </devices>
+        <applymask />
+    </template>
+
+    <!-- Applymask Tests -->
+    <template identifier="tmp0B32F7-1B064FA20" id="60020" functionbitmask="0" applymask="0">
+        <name>Apply Heating Summer Mode (Heating off)</name>
+        <devices />
+        <applymask>
+            <hkr_summer />
+        </applymask>
+    </template>
+    <template identifier="tmp0B32F7-1B064FA21" id="60021" functionbitmask="0" applymask="0">
+        <name>Apply Heating Target Temperature</name>
+        <devices />
+        <applymask>
+            <hkr_temperature />
+        </applymask>
+    </template>
+    <template identifier="tmp0B32F7-1B064FA22" id="60022" functionbitmask="0" applymask="0">
+        <name>Apply Heating Holiday Mode</name>
+        <devices />
+        <applymask>
+            <hkr_holidays />
+        </applymask>
+    </template>
+    <template identifier="tmp0B32F7-1B064FA23" id="60023" functionbitmask="0" applymask="0">
+        <name>Apply Heating Time Table</name>
+        <devices />
+        <applymask>
+            <hkr_time_table />
+        </applymask>
+    </template>
+    <template identifier="tmp0B32F7-1B064FA24" id="60024" functionbitmask="0" applymask="0">
+        <name>Apply Switch/Lamp/Actor manuel on/off Setting</name>
+        <devices />
+        <applymask>
+            <relay_manual />
+        </applymask>
+    </template>
+    <template identifier="tmp0B32F7-1B064FA25" id="60025" functionbitmask="0" applymask="0">
+        <name>Apply Switch/Lamp/Actor Automatic Time Table</name>
+        <devices />
+        <applymask>
+            <relay_automatic />
+        </applymask>
+    </template>
+    <template identifier="tmp0B32F7-1B064FA26" id="60026" functionbitmask="0" applymask="0">
+        <name>Apply Lamp/Blind Level</name>
+        <devices />
+        <applymask>
+            <level />
+        </applymask>
+    </template>
+    <template identifier="tmp0B32F7-1B064FA27" id="60027" functionbitmask="0" applymask="0">
+        <name>Apply Lamp Color</name>
+        <devices />
+        <applymask>
+            <color />
+        </applymask>
+    </template>
+    <template identifier="tmp0B32F7-1B064FA28" id="60028" functionbitmask="0" applymask="0">
+        <name>Apply Phone Dialhelper</name>
+        <devices />
+        <applymask>
+            <dialhelper />
+        </applymask>
+    </template>
+</templatelist>

--- a/tests/test_fritzhome.py
+++ b/tests/test_fritzhome.py
@@ -108,6 +108,11 @@ class TestFritzhome(object):
         eq_(devices[0].name, "Steckdose")
         eq_(devices[1].name, "FRITZ!DECT Rep 100 #1")
 
+        self.fritz._request.assert_called_with(
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {"sid": None, "switchcmd": "getdevicelistinfos"},
+        )
+
     def test_get_device_name(self):
         self.mock.side_effect = ["testname"]
 
@@ -116,6 +121,39 @@ class TestFritzhome(object):
         self.fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
             {"sid": None, "ain": "1234", "switchcmd": "getswitchname"},
+        )
+
+    def test_get_template_by_ain(self):
+        self.mock.side_effect = [
+            Helper.response("templates/template_list"),
+            Helper.response("templates/template_list"),
+        ]
+
+        self.fritz.update_templates()
+        device = self.fritz.get_template_by_ain("tmp0B32F7-1B0650682")
+        eq_(device.ain, "tmp0B32F7-1B0650682")
+
+    def test_aha_get_templates(self):
+        self.mock.side_effect = [
+            Helper.response("templates/template_list"),
+        ]
+        self.fritz.update_templates()
+
+        templates = self.fritz.get_templates()
+        eq_(templates[0].name, "Base Data")
+        eq_(templates[1].name, "One Device")
+
+        self.fritz._request.assert_called_with(
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {"sid": None, "switchcmd": "gettemplatelistinfos"},
+        )
+
+    def test_aha_apply_template(self):
+        self.fritz.apply_template("1234")
+
+        self.fritz._request.assert_called_with(
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {"sid": None, "ain": "1234", "switchcmd": "applytemplate"},
         )
 
     def test_set_target_temperature(self):

--- a/tests/test_fritzhometemplate.py
+++ b/tests/test_fritzhometemplate.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from nose.tools import eq_, assert_true, assert_false
+from unittest.mock import MagicMock
+
+from .helper import Helper
+
+from pyfritzhome import Fritzhome
+
+
+class TestFritzhomeTemplate(object):
+    def setup(self):
+        self.mock = MagicMock()
+        self.fritz = Fritzhome("10.0.0.1", "user", "pass")
+        self.fritz._request = self.mock
+        self.fritz._devices = {}
+
+        self.mock.side_effect = [Helper.response("templates/template_list")]
+
+        self.fritz.update_templates()
+
+    def test_template_init(self):
+        template = self.fritz.get_template_by_ain("tmp0B32F7-1B0650682")
+
+        eq_(template.ain, "tmp0B32F7-1B0650682")
+        eq_(template._functionsbitmask, 320)
+        assert_false(template.apply_hkr_summer)
+        assert_false(template.apply_hkr_temperature)
+        assert_false(template.apply_hkr_holidays)
+        assert_false(template.apply_hkr_time_table)
+        assert_false(template.apply_relay_manual)
+        assert_false(template.apply_relay_automatic)
+        assert_false(template.apply_level)
+        assert_false(template.apply_color)
+        assert_false(template.apply_dialhelper)
+
+    def test_template_with_single_device(self):
+        template = self.fritz.get_template_by_ain("tmp0B32F7-1B0650234")
+
+        eq_(template.devices, ["08735 0525249"])
+
+    def test_template_with_multiple_devices(self):
+        template = self.fritz.get_template_by_ain("tmp0B32F7-1C40A2B8A")
+
+        expected_devices = set(["08735 0525249",
+                                "08735 0525249",
+                                "08735 0340143",
+                                "08735 0526125"])
+        eq_(len(expected_devices.intersection(template.devices)), len(expected_devices))
+
+    def test_template_applies_hkr_summer(self):
+        template = self.fritz.get_template_by_ain("tmp0B32F7-1B064FA20")
+
+        assert_true(template.apply_hkr_summer)
+        assert_false(template.apply_hkr_temperature)
+        assert_false(template.apply_hkr_holidays)
+        assert_false(template.apply_hkr_time_table)
+        assert_false(template.apply_relay_manual)
+        assert_false(template.apply_relay_automatic)
+        assert_false(template.apply_level)
+        assert_false(template.apply_color)
+        assert_false(template.apply_dialhelper)
+
+    def test_template_applies_hkr_temperature(self):
+        template = self.fritz.get_template_by_ain("tmp0B32F7-1B064FA21")
+
+        assert_false(template.apply_hkr_summer)
+        assert_true(template.apply_hkr_temperature)
+        assert_false(template.apply_hkr_holidays)
+        assert_false(template.apply_hkr_time_table)
+        assert_false(template.apply_relay_manual)
+        assert_false(template.apply_relay_automatic)
+        assert_false(template.apply_level)
+        assert_false(template.apply_color)
+        assert_false(template.apply_dialhelper)
+
+    def test_template_applies_hkr_holidays(self):
+        template = self.fritz.get_template_by_ain("tmp0B32F7-1B064FA22")
+
+        assert_false(template.apply_hkr_summer)
+        assert_false(template.apply_hkr_temperature)
+        assert_true(template.apply_hkr_holidays)
+        assert_false(template.apply_hkr_time_table)
+        assert_false(template.apply_relay_manual)
+        assert_false(template.apply_relay_automatic)
+        assert_false(template.apply_level)
+        assert_false(template.apply_color)
+        assert_false(template.apply_dialhelper)
+
+    def test_template_applies_hkr_time_table(self):
+        template = self.fritz.get_template_by_ain("tmp0B32F7-1B064FA23")
+
+        assert_false(template.apply_hkr_summer)
+        assert_false(template.apply_hkr_temperature)
+        assert_false(template.apply_hkr_holidays)
+        assert_true(template.apply_hkr_time_table)
+        assert_false(template.apply_relay_manual)
+        assert_false(template.apply_relay_automatic)
+        assert_false(template.apply_level)
+        assert_false(template.apply_color)
+        assert_false(template.apply_dialhelper)
+
+    def test_template_applies_relay_manual(self):
+        template = self.fritz.get_template_by_ain("tmp0B32F7-1B064FA24")
+
+        assert_false(template.apply_hkr_summer)
+        assert_false(template.apply_hkr_temperature)
+        assert_false(template.apply_hkr_holidays)
+        assert_false(template.apply_hkr_time_table)
+        assert_true(template.apply_relay_manual)
+        assert_false(template.apply_relay_automatic)
+        assert_false(template.apply_level)
+        assert_false(template.apply_color)
+        assert_false(template.apply_dialhelper)
+
+    def test_template_applies_relay_automatic(self):
+        template = self.fritz.get_template_by_ain("tmp0B32F7-1B064FA25")
+
+        assert_false(template.apply_hkr_summer)
+        assert_false(template.apply_hkr_temperature)
+        assert_false(template.apply_hkr_holidays)
+        assert_false(template.apply_hkr_time_table)
+        assert_false(template.apply_relay_manual)
+        assert_true(template.apply_relay_automatic)
+        assert_false(template.apply_level)
+        assert_false(template.apply_color)
+        assert_false(template.apply_dialhelper)
+
+    def test_template_applies_level(self):
+        template = self.fritz.get_template_by_ain("tmp0B32F7-1B064FA26")
+
+        assert_false(template.apply_hkr_summer)
+        assert_false(template.apply_hkr_temperature)
+        assert_false(template.apply_hkr_holidays)
+        assert_false(template.apply_hkr_time_table)
+        assert_false(template.apply_relay_manual)
+        assert_false(template.apply_relay_automatic)
+        assert_true(template.apply_level)
+        assert_false(template.apply_color)
+        assert_false(template.apply_dialhelper)
+
+    def test_template_applies_color(self):
+        template = self.fritz.get_template_by_ain("tmp0B32F7-1B064FA27")
+
+        assert_false(template.apply_hkr_summer)
+        assert_false(template.apply_hkr_temperature)
+        assert_false(template.apply_hkr_holidays)
+        assert_false(template.apply_hkr_time_table)
+        assert_false(template.apply_relay_manual)
+        assert_false(template.apply_relay_automatic)
+        assert_false(template.apply_level)
+        assert_true(template.apply_color)
+        assert_false(template.apply_dialhelper)
+
+    def test_template_applies_dialhelper(self):
+        template = self.fritz.get_template_by_ain("tmp0B32F7-1B064FA28")
+
+        assert_false(template.apply_hkr_summer)
+        assert_false(template.apply_hkr_temperature)
+        assert_false(template.apply_hkr_holidays)
+        assert_false(template.apply_hkr_time_table)
+        assert_false(template.apply_relay_manual)
+        assert_false(template.apply_relay_automatic)
+        assert_false(template.apply_level)
+        assert_false(template.apply_color)
+        assert_true(template.apply_dialhelper)


### PR DESCRIPTION
First attempt to add Fritz-template support to both CLI and library (fixes  #50).

On the library side I added a new `FritzhomeEntityBase` class and moved common functionality there since devices and templates share a couple of similarities like _ain_ and _functionbitmask_. Within `Fritzhome` I mirrored the handling of devices with appropriate dict as well as methods for get and update.

On the CLI side I added a new _template_ subcommand with list and apply options.

I tested this manually against my actual FRITZ!Box 7490 but did not yet write corresponding unit tests, which I'll of course add after your feedback.

Please let me know if you agree with the general approach and/or if you see anything else which needs to be improved.