### PR TITLE
Allow free color selection in FRITZ!DECT 500

### DIFF
--- a/pyfritzhome/devicetypes/fritzhomedevicelightbulb.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicelightbulb.py
@@ -15,6 +15,8 @@ class FritzhomeDeviceLightBulb(FritzhomeDeviceBase):
     level = None
     hue = None
     saturation = None
+    unmapped_hue = None
+    unmapped_saturation = None
     color_temp = None
     color_mode = None
     supported_color_mode = None
@@ -65,10 +67,16 @@ class FritzhomeDeviceLightBulb(FritzhomeDeviceBase):
             self.saturation = self.get_node_value_as_int(colorcontrol_element,
                                                          "saturation")
 
+            self.unmapped_hue = self.get_node_value_as_int(colorcontrol_element, "unmapped_hue")
+
+            self.unmapped_saturation = self.get_node_value_as_int(colorcontrol_element,
+                                                         "unmapped_saturation")
         except ValueError:
             # reset values after color mode changed
             self.hue = None
             self.saturation = None
+            self.unmapped_hue = None
+            self.unmapped_saturation = None
 
         try:
             self.color_temp = self.get_node_value_as_int(colorcontrol_element,
@@ -103,7 +111,11 @@ class FritzhomeDeviceLightBulb(FritzhomeDeviceBase):
 
     def set_color(self, hsv, duration=0):
         """Set HSV color."""
-        self._fritz.set_color(self.ain, hsv, duration)
+        self._fritz.set_color(self.ain, hsv, duration, True)
+
+    def set_unmapped_color(self, hsv, duration=0):
+        """Set unmapped HSV color (Free color selection)."""
+        self._fritz.set_color(self.ain, hsv, duration, False)
 
     def get_color_temps(self):
         """Get the supported color temperatures energy."""

--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -281,7 +281,7 @@ class Fritzhome(object):
             colors[name] = values
         return colors
 
-    def set_color(self, ain, hsv, duration=0):
+    def set_color(self, ain, hsv, duration=0, mapped=True):
         """Set hue and saturation.
 
         hsv: HUE colorspace element obtained from get_colors()
@@ -292,7 +292,11 @@ class Fritzhome(object):
             'saturation': int(hsv[1]),
             "duration": int(duration)*10
         }
-        self._aha_request("setcolor", ain=ain, param=params)
+        if mapped:
+            self._aha_request("setcolor", ain=ain, param=params)
+        else:
+            # undocumented API method for free color selection
+            self._aha_request("setunmappedcolor", ain=ain, param=params)
 
     def get_color_temps(self, ain):
         """Get temperatures supported by this lightbulb."""

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -9,7 +9,7 @@ class Helper(object):
     @staticmethod
     def response(filename: str) -> str:
         if filename not in Helper.__responses:
-            with open("tests/responses/" + filename + ".xml", "r") as file:
+            with open("tests/responses/" + filename + ".xml", "r", encoding="UTF-8") as file:
                 _LOGGER.debug(f"{filename} not cached yet. Adding to cache.")
                 Helper.__responses[filename] = file.read()
         _LOGGER.debug(f"Returning response for {filename} ")

--- a/tests/test_fritzhomedevicelightbulb.py
+++ b/tests/test_fritzhomedevicelightbulb.py
@@ -164,3 +164,35 @@ class TestFritzhomeDeviceLightBulb(object):
             '6500'
             ]
         eq_(temps, expected_temps)
+
+    def test_set_color(self):
+        self.mock.side_effect = [
+            Helper.response("lightbulb/device_FritzDECT500_34_12_16"),
+            "1",
+        ]
+
+        self.fritz.update_devices()
+        device = self.fritz.get_device_by_ain("12345-1")
+
+        device.set_color(["180", "200"], 0)
+
+        device._fritz._request.assert_called_with(
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {"switchcmd": "setcolor", "sid": None, "hue": 180, "saturation": 200, "duration": 0, "ain": "12345-1"},
+        )
+
+    def test_set_unmapped_color(self):
+        self.mock.side_effect = [
+            Helper.response("lightbulb/device_FritzDECT500_34_12_16"),
+            "1",
+        ]
+
+        self.fritz.update_devices()
+        device = self.fritz.get_device_by_ain("12345-1")
+
+        device.set_unmapped_color(["180", "200"], 0)
+
+        device._fritz._request.assert_called_with(
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {"switchcmd": "setunmappedcolor", "sid": None, "hue": 180, "saturation": 200, "duration": 0, "ain": "12345-1"},
+        )


### PR DESCRIPTION
I was curious how the latest update of the Fritz Smart Home app can do free selection of colors.
There is an undocumented API method for this 😃. At least on Fritz!OS 7.29, I'm not sure about older Versions.

I kept the existing method for compatibility and because that is the one from the API docs.

_I have no idea why they implemented it like that..._