### PR TITLE
adds RADEMACHER RolloTron DECT 1213 to list of tested devices

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,8 @@ Tested Devices
 * `Comet DECT`_
 * `Panasonic KX-HNS101`
 * `Magenta Smarthome Tür-/Fensterkontakt optisch`_
+* `RADEMACHER RolloTron DECT 1213`_
+
 
 
 fritzhome CLI tool
@@ -115,3 +117,4 @@ References
 .. _FRITZ!DECT 500: https://avm.de/produkte/fritzdect/fritzdect-500/
 .. _FRITZ!Box 6490 Cable: https://avm.de/produkte/fritzbox/fritzbox-6490-cable/
 .. _Magenta Smarthome Tür-/Fensterkontakt optisch: https://www.smarthome.de/geraete/smarthome-tuer-fensterkontakt-optisch-weiss
+.. _RADEMACHER RolloTron DECT 1213: https://www.rademacher.de/shop/rollladen-sonnenschutz/elektrischer-gurtwickler/rollotron-dect-1213


### PR DESCRIPTION
Here the changes for the README
Would be nice, if you could make a new tag :-). Thanks!