### PR TITLE
set properties to None in case of errors

### DIFF
--- a/pyfritzhome/devicetypes/fritzhomedevicealarm.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicealarm.py
@@ -32,4 +32,4 @@ class FritzhomeDeviceAlarm(FritzhomeDeviceBase):
         try:
             self.alert_state = self.get_node_value_as_int_as_bool(val, "state")
         except (Exception, ValueError):
-            pass
+            self.alert_state = None

--- a/pyfritzhome/devicetypes/fritzhomedeviceswitch.py
+++ b/pyfritzhome/devicetypes/fritzhomedeviceswitch.py
@@ -31,9 +31,16 @@ class FritzhomeDeviceSwitch(FritzhomeDeviceBase):
 
     def _update_switch_from_node(self, node):
         val = node.find("switch")
-        self.switch_state = self.get_node_value_as_int_as_bool(val, "state")
+        try:
+            self.switch_state = self.get_node_value_as_int_as_bool(val, "state")
+        except Exception:
+            self.switch_state = None
         self.switch_mode = self.get_node_value(val, "mode")
-        self.lock = bool(self.get_node_value(val, "lock"))
+        try:
+            self.lock = self.get_node_value_as_int_as_bool(val, "lock")
+        except Exception:
+            self.lock = None
+
         # optional value
         try:
             self.device_lock = self.get_node_value_as_int_as_bool(val, "devicelock")


### PR DESCRIPTION
based on the [AHA api](https://avm.de/fileadmin/user_upload/Global/Service/Schnittstellen/AHA-HTTP-Interface.pdf) reference `state`and `lock` for switches, as well `state` for alert entities can be empty in case of erros, so the related properties should be set to None.

This will also fix home-assistant/core/issues/72217