### PR TITLE
Return native voltage value

### DIFF
--- a/pyfritzhome/devicetypes/fritzhomedevicepowermeter.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicepowermeter.py
@@ -33,7 +33,7 @@ class FritzhomeDevicePowermeter(FritzhomeDeviceBase):
         self.power = int(val.findtext("power"))
         self.energy = int(val.findtext("energy"))
         try:
-            self.voltage = float(int(val.findtext("voltage")) / 1000)
+            self.voltage = int(val.findtext("voltage"))
         except Exception:
             pass
 


### PR DESCRIPTION
This removes the division by 1000 on voltage value, since all other powermeter values are also returned "native"

- this will also fix home-assistant/core/issues/73224