### PR TITLE
Add calculated current property to powermeter

### DIFF
--- a/pyfritzhome/devicetypes/fritzhomedevicepowermeter.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicepowermeter.py
@@ -14,6 +14,7 @@ class FritzhomeDevicePowermeter(FritzhomeDeviceBase):
     power = None
     energy = None
     voltage = None
+    current = None
 
     def _update_from_node(self, node):
         super()._update_from_node(node)
@@ -35,6 +36,7 @@ class FritzhomeDevicePowermeter(FritzhomeDeviceBase):
         self.energy = int(val.findtext("energy"))
         try:
             self.voltage = int(val.findtext("voltage"))
+            self.current = self.power / self.voltage / 1000
         except Exception:
             pass
 

--- a/tests/responses/powermeter/device_list.xml
+++ b/tests/responses/powermeter/device_list.xml
@@ -10,8 +10,9 @@
             <devicelock>0</devicelock>
         </switch>
         <powermeter>
-            <power>0</power>
+            <power>1000</power>
             <energy>707</energy>
+            <voltage>230000</voltage>
         </powermeter>
         <temperature>
             <celsius>285</celsius>

--- a/tests/test_fritzhomedevicepowermeter.py
+++ b/tests/test_fritzhomedevicepowermeter.py
@@ -27,7 +27,7 @@ class TestFritzhomeDevicePowermeter(object):
         eq_(device.get_switch_power(), 18000)
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": u"08761 0000434", "switchcmd": "getswitchpower", "sid": None},
+            {"ain": "08761 0000434", "switchcmd": "getswitchpower", "sid": None},
         )
 
     def test_get_switch_energy(self):
@@ -42,5 +42,19 @@ class TestFritzhomeDevicePowermeter(object):
         eq_(device.get_switch_energy(), 2000)
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": u"08761 0000434", "switchcmd": "getswitchenergy", "sid": None},
+            {"ain": "08761 0000434", "switchcmd": "getswitchenergy", "sid": None},
         )
+
+    def test_get_switch_powermeter_properties(self):
+        self.mock.side_effect = [
+            Helper.response("powermeter/device_list"),
+            "2000",
+        ]
+
+        self.fritz.update_devices()
+        device = self.fritz.get_device_by_ain("08761 0000434")
+
+        eq_(device.energy, 707)
+        eq_(device.power, 1000)
+        eq_(device.voltage, 230000)
+        eq_(device.current, device.power / device.voltage / 1000)


### PR DESCRIPTION
This will add a new property `current` to the power meter.
This is calculated from the `power` and `voltage` property and divided by 1000 to return `mA`  since power is `mW` and voltage is m`V` (_`power` / `voltage` */ 1000_)