### PR TITLE
avoid division by zero and reset on faulty base values

### DIFF
--- a/pyfritzhome/devicetypes/fritzhomedevicepowermeter.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicepowermeter.py
@@ -36,9 +36,17 @@ class FritzhomeDevicePowermeter(FritzhomeDeviceBase):
         self.energy = int(val.findtext("energy"))
         try:
             self.voltage = int(val.findtext("voltage"))
-            self.current = self.power / self.voltage * 1000
         except Exception:
             pass
+
+        if (
+            isinstance(self.power, int)
+            and isinstance(self.voltage, int)
+            and self.voltage > 0
+        ):
+            self.current = self.power / self.voltage * 1000
+        else:
+            self.current = None
 
     def get_switch_power(self):
         """The switch state."""

--- a/tests/responses/powermeter/device_list_faulty.xml
+++ b/tests/responses/powermeter/device_list_faulty.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<devicelist version="1">
+    <device identifier="08761 0000434" id="17" functionbitmask="896" fwversion="03.33" manufacturer="AVM" productname="FRITZ!DECT 200">
+        <present>1</present>
+        <name>Steckdose</name>
+        <switch>
+            <state>1</state>
+            <mode>auto</mode>
+            <lock>0</lock>
+            <devicelock>0</devicelock>
+        </switch>
+        <powermeter>
+            <power>0</power>
+            <energy>0</energy>
+            <voltage>0</voltage>
+        </powermeter>
+        <temperature>
+            <celsius>285</celsius>
+            <offset>0</offset>
+        </temperature>
+    </device>
+</devicelist>

--- a/tests/test_fritzhomedevicepowermeter.py
+++ b/tests/test_fritzhomedevicepowermeter.py
@@ -58,3 +58,16 @@ class TestFritzhomeDevicePowermeter(object):
         eq_(device.power, 1000)
         eq_(device.voltage, 230000)
         eq_(device.current, 4.3478260869565215)
+
+    def test_faulty_powermeter_properties(self):
+        self.mock.side_effect = [
+            Helper.response("powermeter/device_list_faulty"),
+        ]
+
+        self.fritz.update_devices()
+        device = self.fritz.get_device_by_ain("08761 0000434")
+
+        eq_(device.energy, 0)
+        eq_(device.power, 0)
+        eq_(device.voltage, 0)
+        eq_(device.current, None)


### PR DESCRIPTION
As we know, i case of faulty or unreachable device, `power` and `voltage` values can be 0 (_see https://github.com/home-assistant/core/issues/55799#issuecomment-923762640_)
Therefore, we need to safeguard against a "division by zero" in case of device issues and further should reset the property to `None` as long as no valid values for `power` and `voltage` are available.