### PR TITLE
Update actions & python versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Install pypa/build
@@ -29,6 +29,6 @@ jobs:
           .
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,13 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "pypy3"]
+        python-version: ["3.7", "3.8", "3.9", "pypy3.7"]
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,9 +13,9 @@ license_file = LICENSE
 classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 


### PR DESCRIPTION
Some boring maintenance stuff to get the actions running again 😉 

- update `actions/setup-python` to v4, older versions run on node-12 which is EOL [and will stop working soon ](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
- update `actions/checkout` to v3, master is not maintained anymore and also uses node-12
- update `pypa/gh-action-pypi-publish` to release/v1, master is [not maintained anymore](https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-)
- Drop python 3.6, it is EOL since about a year and not available on runner `ubuntu-latest` anymore.

Nose has not seen a release since 2015 and is not compatible with python >= 3.10. Because of this tests would fail and I did not enable 3.10 and 3.11. I would like to do this in a different PR and migrate to pytest.