### PR TITLE
Run black and flake8 formatting on all files

### DIFF
--- a/pyfritzhome/cli.py
+++ b/pyfritzhome/cli.py
@@ -70,7 +70,6 @@ def list_all(fritz, args):
             print("  level=%s" % device.level)
             print("  levelpercentage=%s" % device.levelpercentage)
             print("  endpositionset=%s" % device.endpositionsset)
-            
 
 
 def device_name(fritz, args):
@@ -93,9 +92,11 @@ def blind_set_open(fritz, args):
     """Command to open the blinds."""
     fritz.set_blind_open(args.ain)
 
+
 def blind_set_close(fritz, args):
     """Command close the blinds."""
     fritz.set_blind_close(args.ain)
+
 
 def blind_set_level_percentage(fritz, args):
     """Command that sets the blind level as percentage."""
@@ -106,9 +107,11 @@ def thermostat_set_target_temperature(fritz, args):
     """Command that sets the thermostat temperature."""
     fritz.set_target_temperature(args.ain, args.temperature)
 
+
 def thermostat_set_window_open(fritz, args):
     """Command that sets the thermostats window state."""
     fritz.set_window_open(args.ain, args.timespan)
+
 
 def switch_get(fritz, args):
     """Command that get the device switch state."""
@@ -218,7 +221,6 @@ def main(args=None):
     subparser.add_argument("ain", type=str, metavar="AIN", help="Actor Identification")
     subparser.set_defaults(func=device_statistics)
 
-
     # blind
     subparser = _sub.add_parser("blind", help="Blind commands")
     _sub_switch = subparser.add_subparsers()
@@ -234,26 +236,45 @@ def main(args=None):
     subparser.set_defaults(func=blind_set_close)
 
     # blind set level in percentage
-    subparser = _sub_switch.add_parser("set_level", help="set level of blinds in percentage (0=open)")
+    subparser = _sub_switch.add_parser(
+        "set_level", help="set level of blinds in percentage (0=open)"
+    )
     subparser.add_argument("ain", type=str, metavar="AIN", help="Actor Identification")
-    subparser.add_argument("level", type=float, metavar="LEVEL", help="blind level in percentage (0=open)")
+    subparser.add_argument(
+        "level", type=float, metavar="LEVEL", help="blind level in percentage (0=open)"
+    )
     subparser.set_defaults(func=blind_set_level_percentage)
-
 
     # thermostat
     subparser = _sub.add_parser("thermostat", help="Thermostat commands")
     _sub_switch = subparser.add_subparsers()
 
     # thermostat target temperature
-    subparser = _sub_switch.add_parser("set_target_temperature", help="set target temperature")
+    subparser = _sub_switch.add_parser(
+        "set_target_temperature", help="set target temperature"
+    )
     subparser.add_argument("ain", type=str, metavar="AIN", help="Actor Identification")
-    subparser.add_argument("temperature", type=float, metavar="TEMPERATURE", help="target temperature in (C)")
+    subparser.add_argument(
+        "temperature",
+        type=float,
+        metavar="TEMPERATURE",
+        help="target temperature in (C)",
+    )
     subparser.set_defaults(func=thermostat_set_target_temperature)
 
     # thermostat window_open
-    subparser = _sub_switch.add_parser("set_window_open", help="set window state to open")
+    subparser = _sub_switch.add_parser(
+        "set_window_open", help="set window state to open"
+    )
     subparser.add_argument("ain", type=str, metavar="AIN", help="Actor Identification")
-    subparser.add_argument("timespan", type=int, metavar="TIMESPAN", nargs='?', default=300, help="Open timespan in seconds (default=300s)")
+    subparser.add_argument(
+        "timespan",
+        type=int,
+        metavar="TIMESPAN",
+        nargs="?",
+        default=300,
+        help="Open timespan in seconds (default=300s)",
+    )
     subparser.set_defaults(func=thermostat_set_window_open)
 
     # switch

--- a/pyfritzhome/devicetypes/fritzhomedeviceblind.py
+++ b/pyfritzhome/devicetypes/fritzhomedeviceblind.py
@@ -2,7 +2,6 @@
 
 import logging
 
-from xml.etree import ElementTree
 from .fritzhomedevicebase import FritzhomeDeviceBase
 from .fritzhomedevicefeatures import FritzhomeDeviceFeatures
 
@@ -11,7 +10,7 @@ _LOGGER = logging.getLogger(__name__)
 
 class FritzhomeDeviceBlind(FritzhomeDeviceBase):
     """The Fritzhome Device class."""
-    
+
     tx_busy = None
     endpositionsset = None
     level = None
@@ -32,36 +31,44 @@ class FritzhomeDeviceBlind(FritzhomeDeviceBase):
         return self._has_feature(FritzhomeDeviceFeatures.BLIND)
 
     def _update_blind_from_node(self, node):
-        #print("update from blind")
+        # print("update from blind")
         try:
             self.tx_busy = self.get_node_value_as_int_as_bool(node, "txbusy")
         except Exception:
             pass
         blind_element = node.find("blind")
         try:
-            self.endpositionsset = self.get_node_value_as_int_as_bool(blind_element, "endpositionsset")
+            self.endpositionsset = self.get_node_value_as_int_as_bool(
+                blind_element, "endpositionsset"
+            )
         except Exception:
             pass
         levelcontrol_element = node.find("levelcontrol")
         try:
             self.level = self.get_node_value_as_int(levelcontrol_element, "level")
-            self.levelpercentage = self.get_node_value_as_int(levelcontrol_element, "levelpercentage")
+            self.levelpercentage = self.get_node_value_as_int(
+                levelcontrol_element, "levelpercentage"
+            )
         except Exception:
             pass
-    
+
     def get_level(self):
         return self.level
-    
+
     def get_level_percentage(self):
         return self.levelpercentage
-        
+
     def set_level(self, level):
         self._fritz.set_level(self.ain, level)
+
     def set_level_percentage(self, levelpercentage):
         self._fritz.set_level_percentage(self.ain, levelpercentage)
+
     def set_blind_open(self):
         self._fritz.set_blind_open(self.ain)
+
     def set_blind_close(self):
         self._fritz.set_blind_close(self.ain)
+
     def set_blind_stop(self):
         self._fritz.set_blind_stop(self.ain)

--- a/pyfritzhome/devicetypes/fritzhomedevicelightbulb.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicelightbulb.py
@@ -56,7 +56,8 @@ class FritzhomeDeviceLightBulb(FritzhomeDeviceBase):
             self.color_mode = colorcontrol_element.attrib.get("current_mode")
 
             self.supported_color_mode = colorcontrol_element.attrib.get(
-                "supported_modes")
+                "supported_modes"
+            )
 
         except ValueError:
             pass
@@ -64,13 +65,17 @@ class FritzhomeDeviceLightBulb(FritzhomeDeviceBase):
         try:
             self.hue = self.get_node_value_as_int(colorcontrol_element, "hue")
 
-            self.saturation = self.get_node_value_as_int(colorcontrol_element,
-                                                         "saturation")
+            self.saturation = self.get_node_value_as_int(
+                colorcontrol_element, "saturation"
+            )
 
-            self.unmapped_hue = self.get_node_value_as_int(colorcontrol_element, "unmapped_hue")
+            self.unmapped_hue = self.get_node_value_as_int(
+                colorcontrol_element, "unmapped_hue"
+            )
 
-            self.unmapped_saturation = self.get_node_value_as_int(colorcontrol_element,
-                                                         "unmapped_saturation")
+            self.unmapped_saturation = self.get_node_value_as_int(
+                colorcontrol_element, "unmapped_saturation"
+            )
         except ValueError:
             # reset values after color mode changed
             self.hue = None
@@ -79,8 +84,9 @@ class FritzhomeDeviceLightBulb(FritzhomeDeviceBase):
             self.unmapped_saturation = None
 
         try:
-            self.color_temp = self.get_node_value_as_int(colorcontrol_element,
-                                                         "temperature")
+            self.color_temp = self.get_node_value_as_int(
+                colorcontrol_element, "temperature"
+            )
 
         except ValueError:
             # reset values after color mode changed

--- a/pyfritzhome/devicetypes/fritzhomedevicetemperature.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicetemperature.py
@@ -48,7 +48,8 @@ class FritzhomeDeviceTemperature(FritzhomeDeviceBase):
         humidity_element = node.find("humidity")
         if humidity_element is not None:
             try:
-                self.rel_humidity = self.get_node_value_as_int(humidity_element,
-                                                               "rel_humidity")
+                self.rel_humidity = self.get_node_value_as_int(
+                    humidity_element, "rel_humidity"
+                )
             except ValueError:
                 pass

--- a/pyfritzhome/devicetypes/fritzhomedevicethermostat.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicethermostat.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import logging,time
+import logging
+import time
 
 from .fritzhomedevicebase import FritzhomeDeviceBase
 from .fritzhomedevicefeatures import FritzhomeDeviceFeatures
@@ -67,9 +68,10 @@ class FritzhomeDeviceThermostat(FritzhomeDeviceBase):
             self.window_open = self.get_node_value_as_int_as_bool(
                 hkr_element, "windowopenactiv"
             )
-            self.window_open_endtime = self.get_node_value_as_int(
-                hkr_element, "windowopenactiveendtime"
-            ) - time.time()
+            self.window_open_endtime = (
+                self.get_node_value_as_int(hkr_element, "windowopenactiveendtime")
+                - time.time()
+            )
             if self.window_open_endtime < 0:
                 self.window_open_endtime = 0
             self.summer_active = self.get_node_value_as_int_as_bool(

--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -34,7 +34,9 @@ class Fritzhome(object):
 
     def _request(self, url, params=None, timeout=10):
         """Send a request with parameters."""
-        rsp = self._session.get(url, params=params, timeout=timeout, verify=self._ssl_verify)
+        rsp = self._session.get(
+            url, params=params, timeout=timeout, verify=self._ssl_verify
+        )
         rsp.raise_for_status()
         return rsp.text.strip()
 
@@ -224,13 +226,15 @@ class Fritzhome(object):
         elif temp > max(range(16, 56)):
             temp = 254
 
-        self._aha_request("sethkrtsoll", ain=ain, param={'param': temp})
+        self._aha_request("sethkrtsoll", ain=ain, param={"param": temp})
 
     def set_window_open(self, ain, seconds):
         """Set the thermostate target temperature."""
-        endtimestamp =  int(time.time() + seconds)
+        endtimestamp = int(time.time() + seconds)
 
-        self._aha_request("sethkrwindowopen", ain=ain, param={'endtimestamp': endtimestamp})
+        self._aha_request(
+            "sethkrwindowopen", ain=ain, param={"endtimestamp": endtimestamp}
+        )
 
     def get_comfort_temperature(self, ain):
         """Get the thermostate comfort temperature."""
@@ -249,24 +253,24 @@ class Fritzhome(object):
 
     def set_state_off(self, ain):
         """Set the switch/actuator/lightbulb to on state."""
-        self._aha_request("setsimpleonoff", ain=ain, param={'onoff': 0})
+        self._aha_request("setsimpleonoff", ain=ain, param={"onoff": 0})
 
     def set_state_on(self, ain):
         """Set the switch/actuator/lightbulb to on state."""
-        self._aha_request("setsimpleonoff", ain=ain, param={'onoff': 1})
+        self._aha_request("setsimpleonoff", ain=ain, param={"onoff": 1})
 
     def set_state_toggle(self, ain):
         """Toggle the switch/actuator/lightbulb state."""
-        self._aha_request("setsimpleonoff", ain=ain, param={'onoff': 2})
+        self._aha_request("setsimpleonoff", ain=ain, param={"onoff": 2})
 
     def set_level(self, ain, level):
         """Set level/brightness/height in interval [0,255]."""
         if level < 0:
-            level = 0      # 0%
+            level = 0  # 0%
         elif level > 255:
-            level = 255    # 100 %
+            level = 255  # 100 %
 
-        self._aha_request("setlevel", ain=ain, param={'level': int(level)})
+        self._aha_request("setlevel", ain=ain, param={"level": int(level)})
 
     def set_level_percentage(self, ain, level):
         """Set level/brightness/height in interval [0,100]."""
@@ -275,7 +279,7 @@ class Fritzhome(object):
         elif level > 100:
             level = 100
 
-        self._aha_request("setlevelpercentage", ain=ain, param={'level': int(level)})
+        self._aha_request("setlevelpercentage", ain=ain, param={"level": int(level)})
 
     def _get_colordefaults(self, ain):
         plain = self._aha_request("getcolordefaults", ain=ain)
@@ -285,17 +289,11 @@ class Fritzhome(object):
         """Get colors (HSV-space) supported by this lightbulb."""
         colordefaults = self._get_colordefaults(ain)
         colors = {}
-        for hs in colordefaults.iter('hs'):
+        for hs in colordefaults.iter("hs"):
             name = hs.find("name").text.strip()
             values = []
             for st in hs.iter("color"):
-                values.append(
-                    (
-                        st.get("hue"),
-                        st.get("sat"),
-                        st.get("val")
-                    )
-                )
+                values.append((st.get("hue"), st.get("sat"), st.get("val")))
             colors[name] = values
         return colors
 
@@ -306,9 +304,9 @@ class Fritzhome(object):
         duration: Speed of change in seconds, 0 = instant
         """
         params = {
-            'hue': int(hsv[0]),
-            'saturation': int(hsv[1]),
-            "duration": int(duration)*10
+            "hue": int(hsv[0]),
+            "saturation": int(hsv[1]),
+            "duration": int(duration) * 10,
         }
         if mapped:
             self._aha_request("setcolor", ain=ain, param=params)
@@ -320,7 +318,7 @@ class Fritzhome(object):
         """Get temperatures supported by this lightbulb."""
         colordefaults = self._get_colordefaults(ain)
         temperatures = []
-        for temp in colordefaults.iter('temp'):
+        for temp in colordefaults.iter("temp"):
             temperatures.append(temp.get("value"))
         return temperatures
 
@@ -330,20 +328,20 @@ class Fritzhome(object):
         temperature: temperature element obtained from get_temperatures()
         duration: Speed of change in seconds, 0 = instant
         """
-        params = {
-            'temperature': int(temperature),
-            "duration": int(duration)*10
-        }
+        params = {"temperature": int(temperature), "duration": int(duration) * 10}
         self._aha_request("setcolortemperature", ain=ain, param=params)
 
-    #blinds
+    # blinds
     # states: open, close, stop
     def _set_blind_state(self, ain, state):
         self._aha_request("setblind", ain=ain, param={"target": state})
+
     def set_blind_open(self, ain):
         self._set_blind_state(ain, "open")
+
     def set_blind_close(self, ain):
         self._set_blind_state(ain, "close")
+
     def set_blind_stop(self, ain):
         self._set_blind_state(ain, "stop")
 

--- a/pyfritzhome/fritzhomedevice.py
+++ b/pyfritzhome/fritzhomedevice.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 
+from .devicetypes import FritzhomeTemplate  # noqa: F401
 from .devicetypes import (
     FritzhomeDeviceAlarm,
+    FritzhomeDeviceBlind,
     FritzhomeDeviceButton,
+    FritzhomeDeviceLightBulb,
     FritzhomeDevicePowermeter,
     FritzhomeDeviceRepeater,
     FritzhomeDeviceSwitch,
     FritzhomeDeviceTemperature,
     FritzhomeDeviceThermostat,
-    FritzhomeDeviceLightBulb,
-    FritzhomeDeviceBlind,
-    FritzhomeTemplate,
 )
 
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -9,7 +9,9 @@ class Helper(object):
     @staticmethod
     def response(filename: str) -> str:
         if filename not in Helper.__responses:
-            with open("tests/responses/" + filename + ".xml", "r", encoding="UTF-8") as file:
+            with open(
+                "tests/responses/" + filename + ".xml", "r", encoding="UTF-8"
+            ) as file:
                 _LOGGER.debug(f"{filename} not cached yet. Adding to cache.")
                 Helper.__responses[filename] = file.read()
         _LOGGER.debug(f"Returning response for {filename} ")

--- a/tests/test_fritzhome.py
+++ b/tests/test_fritzhome.py
@@ -58,7 +58,8 @@ class TestFritzhome(object):
                 "sid": None,
                 "switchcmd": "testcmd",
                 "ain": "1",
-                "a": "1", "b": "2",
+                "a": "1",
+                "b": "2",
             },
         )
 
@@ -175,10 +176,15 @@ class TestFritzhome(object):
             {"sid": None, "ain": "1", "switchcmd": "sethkrtsoll", "param": 254},
         )
 
-    @patch('time.time', MagicMock(return_value=1000))
+    @patch("time.time", MagicMock(return_value=1000))
     def test_set_window_open(self):
         self.fritz.set_window_open("1", 25)
         self.fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"sid": None, "ain": "1", "switchcmd": "sethkrwindowopen", "endtimestamp": 1000 + 25},
+            {
+                "sid": None,
+                "ain": "1",
+                "switchcmd": "sethkrwindowopen",
+                "endtimestamp": 1000 + 25,
+            },
         )

--- a/tests/test_fritzhomedevicebase.py
+++ b/tests/test_fritzhomedevicebase.py
@@ -59,7 +59,7 @@ class TestFritzhomeDeviceBase(object):
         device = self.fritz.get_device_by_ain("08761 0373130")
 
         eq_(device.ain, "08761 0373130")
-        eq_(device.name, u"äöü")
+        eq_(device.name, "äöü")
 
     def test_device_update(self):
         self.mock.side_effect = [
@@ -87,5 +87,5 @@ class TestFritzhomeDeviceBase(object):
         assert_false(device.get_present())
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": u"08761 0000434", "switchcmd": "getswitchpresent", "sid": None},
+            {"ain": "08761 0000434", "switchcmd": "getswitchpresent", "sid": None},
         )

--- a/tests/test_fritzhomedeviceblind.py
+++ b/tests/test_fritzhomedeviceblind.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from nose.tools import eq_, assert_true, assert_false
 from unittest.mock import MagicMock
-from .helper import Helper
 
-from pyfritzhome import Fritzhome, FritzhomeDevice
+from nose.tools import assert_false, assert_true, eq_
+
+from pyfritzhome import Fritzhome
+
+from .helper import Helper
 
 
 class TestFritzhomeDeviceBlind(object):
@@ -24,22 +26,22 @@ class TestFritzhomeDeviceBlind(object):
         device1 = self.fritz.get_device_by_ain("14276 1234567")
         assert_true(device1.present)
         assert_false(device1.tx_busy)
-        
+
         device2 = self.fritz.get_device_by_ain("14276 1234567-1")
         assert_true(device2.present)
         assert_false(device2.tx_busy)
         assert_true(device2.endpositionsset)
-        
+
         eq_(device2.level, 252)
         eq_(device2.levelpercentage, 99)
-        
+
         eq_(device2.get_level(), 252)
         eq_(device2.get_level_percentage(), 99)
 
     def test_set_level(self):
         self.mock.side_effect = [
             Helper.response("blind/device_blind_rollotron1213"),
-            None
+            None,
         ]
 
         self.fritz.update_devices()
@@ -47,14 +49,19 @@ class TestFritzhomeDeviceBlind(object):
 
         device.set_level(100)
         device._fritz._request.assert_called_with(
-           "http://10.0.0.1/webservices/homeautoswitch.lua",
-           {"switchcmd": "setlevel", "sid": None, "ain": "14276 1234567-1", "level": 100},
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {
+                "switchcmd": "setlevel",
+                "sid": None,
+                "ain": "14276 1234567-1",
+                "level": 100,
+            },
         )
 
     def test_set_level_percentage(self):
         self.mock.side_effect = [
             Helper.response("blind/device_blind_rollotron1213"),
-            None
+            None,
         ]
 
         self.fritz.update_devices()
@@ -62,14 +69,19 @@ class TestFritzhomeDeviceBlind(object):
 
         device.set_level_percentage(50)
         device._fritz._request.assert_called_with(
-           "http://10.0.0.1/webservices/homeautoswitch.lua",
-           {"switchcmd": "setlevelpercentage", "sid": None, "ain": "14276 1234567-1", "level": 50},
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {
+                "switchcmd": "setlevelpercentage",
+                "sid": None,
+                "ain": "14276 1234567-1",
+                "level": 50,
+            },
         )
 
     def test_set_blind_open(self):
         self.mock.side_effect = [
             Helper.response("blind/device_blind_rollotron1213"),
-            None
+            None,
         ]
 
         self.fritz.update_devices()
@@ -77,14 +89,19 @@ class TestFritzhomeDeviceBlind(object):
 
         device.set_blind_open()
         device._fritz._request.assert_called_with(
-           "http://10.0.0.1/webservices/homeautoswitch.lua",
-           {"switchcmd": "setblind", "sid": None, "ain": "14276 1234567-1", "target": "open"},
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {
+                "switchcmd": "setblind",
+                "sid": None,
+                "ain": "14276 1234567-1",
+                "target": "open",
+            },
         )
 
     def test_set_blind_close(self):
         self.mock.side_effect = [
             Helper.response("blind/device_blind_rollotron1213"),
-            None
+            None,
         ]
 
         self.fritz.update_devices()
@@ -92,14 +109,19 @@ class TestFritzhomeDeviceBlind(object):
 
         device.set_blind_close()
         device._fritz._request.assert_called_with(
-           "http://10.0.0.1/webservices/homeautoswitch.lua",
-           {"switchcmd": "setblind", "sid": None, "ain": "14276 1234567-1", "target": "close"},
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {
+                "switchcmd": "setblind",
+                "sid": None,
+                "ain": "14276 1234567-1",
+                "target": "close",
+            },
         )
-        
+
     def test_set_blind_stop(self):
         self.mock.side_effect = [
             Helper.response("blind/device_blind_rollotron1213"),
-            None
+            None,
         ]
 
         self.fritz.update_devices()
@@ -107,6 +129,11 @@ class TestFritzhomeDeviceBlind(object):
 
         device.set_blind_stop()
         device._fritz._request.assert_called_with(
-           "http://10.0.0.1/webservices/homeautoswitch.lua",
-           {"switchcmd": "setblind", "sid": None, "ain": "14276 1234567-1", "target": "stop"},
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {
+                "switchcmd": "setblind",
+                "sid": None,
+                "ain": "14276 1234567-1",
+                "target": "stop",
+            },
         )

--- a/tests/test_fritzhomedevicelightbulb.py
+++ b/tests/test_fritzhomedevicelightbulb.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from nose.tools import eq_, assert_true
 from unittest.mock import MagicMock
-from .helper import Helper
+
+from nose.tools import assert_true, eq_
 
 from pyfritzhome import Fritzhome
+
+from .helper import Helper
 
 
 class TestFritzhomeDeviceLightBulb(object):
@@ -36,7 +38,7 @@ class TestFritzhomeDeviceLightBulb(object):
         eq_(device.hue, 358)
         eq_(device.saturation, 180)
         eq_(device.color_temp, None)
-        eq_(device.name, u"FRITZ!DECT 500 Büro")
+        eq_(device.name, "FRITZ!DECT 500 Büro")
 
     def test_device_init_color_temp_mode(self):
         self.mock.side_effect = [
@@ -59,8 +61,7 @@ class TestFritzhomeDeviceLightBulb(object):
         eq_(device.hue, None)
         eq_(device.saturation, None)
         eq_(device.color_temp, 2800)
-        eq_(device.name, u"FRITZ!DECT 500 Büro")
-
+        eq_(device.name, "FRITZ!DECT 500 Büro")
 
     def test_get_colors(self):
         self.mock.side_effect = [
@@ -75,6 +76,7 @@ class TestFritzhomeDeviceLightBulb(object):
         ]
 
         colors = device.get_colors()
+        # fmt: off
         expected_colors = {
             'Rot': [
                 ('358', '180', '230'),
@@ -137,6 +139,7 @@ class TestFritzhomeDeviceLightBulb(object):
                 ('335', '51', '250')
                 ]
             }
+        # fmt: on
         eq_(colors, expected_colors)
 
     def test_get_color_temps(self):
@@ -153,16 +156,16 @@ class TestFritzhomeDeviceLightBulb(object):
 
         temps = device.get_color_temps()
         expected_temps = [
-            '2700',
-            '3000',
-            '3400',
-            '3800',
-            '4200',
-            '4700',
-            '5300',
-            '5900',
-            '6500'
-            ]
+            "2700",
+            "3000",
+            "3400",
+            "3800",
+            "4200",
+            "4700",
+            "5300",
+            "5900",
+            "6500",
+        ]
         eq_(temps, expected_temps)
 
     def test_set_color(self):
@@ -178,7 +181,14 @@ class TestFritzhomeDeviceLightBulb(object):
 
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"switchcmd": "setcolor", "sid": None, "hue": 180, "saturation": 200, "duration": 0, "ain": "12345-1"},
+            {
+                "switchcmd": "setcolor",
+                "sid": None,
+                "hue": 180,
+                "saturation": 200,
+                "duration": 0,
+                "ain": "12345-1",
+            },
         )
 
     def test_set_unmapped_color(self):
@@ -194,5 +204,12 @@ class TestFritzhomeDeviceLightBulb(object):
 
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"switchcmd": "setunmappedcolor", "sid": None, "hue": 180, "saturation": 200, "duration": 0, "ain": "12345-1"},
+            {
+                "switchcmd": "setunmappedcolor",
+                "sid": None,
+                "hue": 180,
+                "saturation": 200,
+                "duration": 0,
+                "ain": "12345-1",
+            },
         )

--- a/tests/test_fritzhomedeviceswitch.py
+++ b/tests/test_fritzhomedeviceswitch.py
@@ -29,7 +29,7 @@ class TestFritzhomeDeviceSwitch(object):
         assert_false(device.get_switch_state())
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": u"08761 0000434", "switchcmd": "getswitchstate", "sid": None},
+            {"ain": "08761 0000434", "switchcmd": "getswitchstate", "sid": None},
         )
 
     def test_set_switch_state_toggle(self):
@@ -44,7 +44,7 @@ class TestFritzhomeDeviceSwitch(object):
         device.set_switch_state_toggle()
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": u"08761 0000434", "switchcmd": "setswitchtoggle", "sid": None},
+            {"ain": "08761 0000434", "switchcmd": "setswitchtoggle", "sid": None},
         )
 
     def test_set_switch_state_on(self):
@@ -59,7 +59,7 @@ class TestFritzhomeDeviceSwitch(object):
         device.set_switch_state_on()
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": u"08761 0000434", "switchcmd": "setswitchon", "sid": None},
+            {"ain": "08761 0000434", "switchcmd": "setswitchon", "sid": None},
         )
 
     def test_set_switch_state_off(self):
@@ -74,5 +74,5 @@ class TestFritzhomeDeviceSwitch(object):
         device.set_switch_state_off()
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": u"08761 0000434", "switchcmd": "setswitchoff", "sid": None},
+            {"ain": "08761 0000434", "switchcmd": "setswitchoff", "sid": None},
         )

--- a/tests/test_fritzhomedevicetemperature.py
+++ b/tests/test_fritzhomedevicetemperature.py
@@ -27,5 +27,5 @@ class TestFritzhomeDeviceTemperature(object):
         eq_(device.get_temperature(), 24.5)
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": u"12345", "switchcmd": "gettemperature", "sid": None},
+            {"ain": "12345", "switchcmd": "gettemperature", "sid": None},
         )

--- a/tests/test_fritzhomedevicethermostat.py
+++ b/tests/test_fritzhomedevicethermostat.py
@@ -49,7 +49,7 @@ class TestFritzhomeDeviceThermostat(object):
         eq_(device.get_target_temperature(), 19.0)
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": u"12345", "switchcmd": "gethkrtsoll", "sid": None},
+            {"ain": "12345", "switchcmd": "gethkrtsoll", "sid": None},
         )
 
     def test_get_eco_temperature(self):
@@ -64,7 +64,7 @@ class TestFritzhomeDeviceThermostat(object):
         eq_(device.get_eco_temperature(), 20.0)
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": u"12345", "switchcmd": "gethkrabsenk", "sid": None},
+            {"ain": "12345", "switchcmd": "gethkrabsenk", "sid": None},
         )
 
     def test_get_comfort_temperature(self):
@@ -79,7 +79,7 @@ class TestFritzhomeDeviceThermostat(object):
         eq_(device.get_comfort_temperature(), 20.5)
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": u"12345", "switchcmd": "gethkrkomfort", "sid": None},
+            {"ain": "12345", "switchcmd": "gethkrkomfort", "sid": None},
         )
 
     def test_hkr_without_temperature_values(self):
@@ -156,7 +156,7 @@ class TestFritzhomeDeviceThermostat(object):
         device.set_hkr_state("on")
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": u"12345", "switchcmd": "sethkrtsoll", "param": 254, "sid": None},
+            {"ain": "12345", "switchcmd": "sethkrtsoll", "param": 254, "sid": None},
         )
 
     def test_hkr_set_state_off(self):
@@ -171,7 +171,7 @@ class TestFritzhomeDeviceThermostat(object):
         device.set_hkr_state("off")
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": u"12345", "switchcmd": "sethkrtsoll", "param": 253, "sid": None},
+            {"ain": "12345", "switchcmd": "sethkrtsoll", "param": 253, "sid": None},
         )
 
     def test_hkr_battery_level(self):

--- a/tests/test_fritzhometemplate.py
+++ b/tests/test_fritzhometemplate.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from nose.tools import eq_, assert_true, assert_false
 from unittest.mock import MagicMock
 
-from .helper import Helper
+from nose.tools import assert_false, assert_true, eq_
 
 from pyfritzhome import Fritzhome
+
+from .helper import Helper
 
 
 class TestFritzhomeTemplate(object):
@@ -43,10 +44,13 @@ class TestFritzhomeTemplate(object):
     def test_template_with_multiple_devices(self):
         template = self.fritz.get_template_by_ain("tmp0B32F7-1C40A2B8A")
 
+        # fmt: off
         expected_devices = set(["08735 0525249",
                                 "08735 0525249",
                                 "08735 0340143",
                                 "08735 0526125"])
+        # fmt: on
+
         eq_(len(expected_devices.intersection(template.devices)), len(expected_devices))
 
     def test_template_applies_hkr_summer(self):


### PR DESCRIPTION
We have pre-commit hooks for `black` and `flake8` but the python files are not (yet) formatted correctly.

The purpose of this PR is to format all files with `pre-commit run --all-files` to avoid code changes in other PRs get buried in a lot of formatting changes.

We could also run `pre-commit` in the actions pipeline to ensure all PRs are formatted correctly. Additionally I suggest adding `isort` to organise the imports automatically. 

_Please merge #74 first_