### PR TITLE
Pass through connection error also during login

### DIFF
--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -92,20 +92,14 @@ class Fritzhome(object):
 
     def login(self):
         """Login and get a valid session ID."""
-        try:
-            (sid, challenge) = self._login_request()
-            if sid == "0000000000000000":
-                secret = self._create_login_secret(challenge, self._password)
-                (sid2, challenge) = self._login_request(
-                    username=self._user, secret=secret
-                )
-                if sid2 == "0000000000000000":
-                    _LOGGER.warning("login failed %s", sid2)
-                    raise LoginError(self._user)
-                self._sid = sid2
-        except Exception as ex:
-            _LOGGER.error(ex)
-            raise LoginError(self._user)
+        (sid, challenge) = self._login_request()
+        if sid == "0000000000000000":
+            secret = self._create_login_secret(challenge, self._password)
+            (sid2, challenge) = self._login_request(username=self._user, secret=secret)
+            if sid2 == "0000000000000000":
+                _LOGGER.warning("login failed %s", sid2)
+                raise LoginError(self._user)
+            self._sid = sid2
 
     def logout(self):
         """Logout."""

--- a/tests/test_fritzhome.py
+++ b/tests/test_fritzhome.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from requests.exceptions import ConnectionError
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -21,7 +22,14 @@ class TestFritzhome(object):
             Helper.response("login_rsp_without_valid_sid"),
         ]
 
-        with pytest.raises(LoginError):
+        with pytest.raises(LoginError) as ex:
+            self.fritz.login()
+        assert str(ex.value) == 'login for user="user" failed'
+
+    def test_login_connection_error(self):
+        self.mock.side_effect = ConnectionError
+
+        with pytest.raises(ConnectionError):
             self.fritz.login()
 
     def test_login(self):


### PR DESCRIPTION
Currently any exception occur during login, will cause a `LoginError`, even it is an connection error.

With this change it is ensured, that every exception (_except the defined `LoginError`_) is passed through (_like every other method does in this lib_), those the user can differentiate if the credentials are wrong or a connection issue occured.