### PR TITLE
adds support for the new login procedure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.7"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.9"]
 
     steps:
       - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyfritzhome
-version = 0.6.8
+version = 0.6.9
 description = Fritz!Box Smarthome Python Library
 long_description = file: README.rst
 long_description_content_type = text/x-rst
@@ -27,7 +27,7 @@ packages = find:
 include_package_data = true
 test_suite = tests
 setup_requires = setuptools
-install_requires = requests
+install_requires = requests; cryptography
 tests_requires = pytest
 
 [options.entry_points]

--- a/tests/responses/login_rsp_with_valid_sid_pbkdf2.xml
+++ b/tests/responses/login_rsp_with_valid_sid_pbkdf2.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><SessionInfo><SID>0000000000000001</SID><Challenge>2$10000$a64b986b521fcbc44d7a9f0adad34b14$1000$b9c232dea345233f5a893b2284931ac8</Challenge><BlockTime>0</BlockTime><Rights></Rights></SessionInfo>

--- a/tests/responses/login_rsp_without_valid_sid_pbkdf2.xml
+++ b/tests/responses/login_rsp_without_valid_sid_pbkdf2.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><SessionInfo><SID>0000000000000000</SID><Challenge>2$10000$a64b986b521fcbc44d7a9f0adad34b14$1000$b9c232dea345233f5a893b2284931ac8</Challenge><BlockTime>0</BlockTime><Rights></Rights></SessionInfo>

--- a/tests/test_fritzhome.py
+++ b/tests/test_fritzhome.py
@@ -13,7 +13,7 @@ from .helper import Helper
 class TestFritzhome(object):
     def setup_method(self):
         self.mock = MagicMock()
-        self.fritz = Fritzhome("10.0.0.1", "user", "pass")
+        self.fritz = Fritzhome("10.0.0.1", "user", "admin123")
         self.fritz._request = self.mock
 
     def test_login_fail(self):
@@ -39,6 +39,26 @@ class TestFritzhome(object):
         ]
 
         self.fritz.login()
+
+    def test_login_pbkdf2(self):
+        self.mock.side_effect = [
+            Helper.response("login_rsp_without_valid_sid_pbkdf2"),
+            Helper.response("login_rsp_with_valid_sid_pbkdf2"),
+        ]
+        """
+        challenge was generated using
+        http://home.mengelke.de/login_sid.lua?version=2 (Fritzbox Anmeldesimulator)
+        response was generated using python code from
+        https://avm.de/fileadmin/user_upload/Global/Service/Schnittstellen/AVM%20Technical%20Note%20-%20Session%20ID_deutsch%20-%20Nov2020.pdf
+        the example challenge and response in this document is faulty and
+        does not work with given example code
+        """
+        self.fritz.login()
+        self.fritz._request.assert_called_with(
+            "http://10.0.0.1/login_sid.lua?version=2",
+            {"username": "user", "response": "b9c232dea345233f5a893b2284931ac8$"
+             "2825c7fbd8cdbcbaf93ca2e8d0798c31cf38394469a9ce89365778dc9103ad82"},
+        )
 
     def test_logout(self):
         self.fritz.logout()


### PR DESCRIPTION
* FRITZ!OS 7.24 and later supports new response generation using PBKDF2
* technical note: https://avm.de/fileadmin/user_upload/Global/Service/Schnittstellen/AVM%20Technical%20Note%20-%20Session%20ID_EN%20-%20Nov2020.pdf
* adds test for login using new variant