### PR TITLE
Add device and unit id property to FritzhomeEntityBase

### DIFF
--- a/pyfritzhome/devicetypes/fritzhomeentitybase.py
+++ b/pyfritzhome/devicetypes/fritzhomeentitybase.py
@@ -43,6 +43,17 @@ class FritzhomeEntityBase(ABC):
 
         self.name = node.findtext("name").strip()
 
+    @property
+    def device_and_unit_id(self):
+        """Get the device and possible unit id."""
+        if self.ain.startswith("tmp") or self.ain.startswith("grp"):
+            return (self.ain, None)
+        elif self.ain.startswith("Z") and len(self.ain) == 19:
+            return (self.ain[0:17], self.ain[17:])
+        elif "-" in self.ain:
+            return tuple(self.ain.split("-"))
+        return (self.ain, None)
+
     # XML Helpers
 
     def get_node_value(self, elem, node):

--- a/tests/test_fritzhomedevicebase.py
+++ b/tests/test_fritzhomedevicebase.py
@@ -4,6 +4,7 @@
 from unittest.mock import MagicMock
 
 from pyfritzhome import Fritzhome
+from pyfritzhome.devicetypes.fritzhomeentitybase import FritzhomeEntityBase
 
 from .helper import Helper
 
@@ -89,3 +90,24 @@ class TestFritzhomeDeviceBase(object):
             "http://10.0.0.1/webservices/homeautoswitch.lua",
             {"ain": "08761 0000434", "switchcmd": "getswitchpresent", "sid": None},
         )
+
+    def test_device_and_unit_id(self):
+        device = FritzhomeEntityBase()
+
+        device.ain = "11630 0114733"
+        assert device.device_and_unit_id == ("11630 0114733", None)
+
+        device.ain = "11630 0114733-1"
+        assert device.device_and_unit_id == ("11630 0114733", "1")
+
+        device.ain = "ZA4C1380C30E07AB1"
+        assert device.device_and_unit_id == ("ZA4C1380C30E07AB1", None)
+
+        device.ain = "ZA4C1380C30E07AB101"
+        assert device.device_and_unit_id == ("ZA4C1380C30E07AB1", "01")
+
+        device.ain = "grp303E4F-3F7D9BE07"
+        assert device.device_and_unit_id == ("grp303E4F-3F7D9BE07", None)
+
+        device.ain = "tmp816271-3F6EB615E"
+        assert device.device_and_unit_id == ("tmp816271-3F6EB615E", None)


### PR DESCRIPTION
Based on the chapter [1.2.1 Identifier für Geräte und Unit](https://avm.de/fileadmin/user_upload/Global/Service/Schnittstellen/AHA-HTTP-Interface.pdf) this adds a property to the `FritzhomeEntityBase`, which return the device id and a possible unit id. This can later be used to identify related entities.