### PR TITLE
Add supported features property to FritzhomeEntityBase

### DIFF
--- a/pyfritzhome/devicetypes/fritzhomedevicefeatures.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicefeatures.py
@@ -5,18 +5,19 @@ from enum import IntFlag
 class FritzhomeDeviceFeatures(IntFlag):
     """The feature list class."""
 
-    LIGHTBULB = 0x0004
-    ALARM = 0x0010
-    UNKNOWN = 0x0020
-    BUTTON = 0x0020
-    THERMOSTAT = 0x0040
-    POWER_METER = 0x0080
-    TEMPERATURE = 0x0100
-    SWITCH = 0x0200
-    DECT_REPEATER = 0x0400
-    MICROPHONE = 0x0800
-    HANFUN = 0x2000
-    SWITCHABLE = 0x8000
-    LEVEL = 0x10000
-    COLOR = 0x20000
-    BLIND = 0x40000
+    HANFUN_DEVICE = 0x0001  # bit 0
+    LIGHTBULB = 0x0004  # bit 2
+    ALARM = 0x0010  # bit 4
+    BUTTON = 0x0020  # bit 5
+    THERMOSTAT = 0x0040  # bit 6
+    POWER_METER = 0x0080  # bit 7
+    TEMPERATURE = 0x0100  # bit 8
+    SWITCH = 0x0200  # bit 9
+    DECT_REPEATER = 0x0400  # bit 10
+    MICROPHONE = 0x0800  # bit 11
+    HANFUN_UNIT = 0x2000  # bit 13
+    SWITCHABLE = 0x8000  # bit 15
+    LEVEL = 0x10000  # bit 16
+    COLOR = 0x20000  # bit 17
+    BLIND = 0x40000  # bit 18
+    HUMIDITY = 0x100000  # bit 20

--- a/pyfritzhome/devicetypes/fritzhomeentitybase.py
+++ b/pyfritzhome/devicetypes/fritzhomeentitybase.py
@@ -18,6 +18,7 @@ class FritzhomeEntityBase(ABC):
     _fritz = None
     ain: str = None
     _functionsbitmask = None
+    supported_features = None
 
     def __init__(self, fritz=None, node=None):
         """Create an entity base object."""
@@ -42,6 +43,11 @@ class FritzhomeEntityBase(ABC):
         self._functionsbitmask = int(node.attrib["functionbitmask"])
 
         self.name = node.findtext("name").strip()
+
+        self.supported_features = []
+        for feature in FritzhomeDeviceFeatures:
+            if self._has_feature(feature):
+                self.supported_features.append(feature)
 
     @property
     def device_and_unit_id(self):

--- a/tests/test_fritzhomedevicealarm.py
+++ b/tests/test_fritzhomedevicealarm.py
@@ -4,6 +4,7 @@
 from unittest.mock import MagicMock
 
 from pyfritzhome import Fritzhome
+from pyfritzhome.devicetypes.fritzhomedevicefeatures import FritzhomeDeviceFeatures
 
 from .helper import Helper
 
@@ -24,6 +25,10 @@ class TestFritzhomeDeviceAlarm(object):
         device = self.fritz.get_device_by_ain("05333 0077045-1")
         assert device.present
         assert device.alert_state
+        assert device.supported_features == [
+            FritzhomeDeviceFeatures.ALARM,
+            FritzhomeDeviceFeatures.HANFUN_UNIT,
+        ]
 
     def test_device_alert_off(self):
         self.mock.side_effect = [

--- a/tests/test_fritzhomedevicebase.py
+++ b/tests/test_fritzhomedevicebase.py
@@ -4,6 +4,7 @@
 from unittest.mock import MagicMock
 
 from pyfritzhome import Fritzhome
+from pyfritzhome.devicetypes.fritzhomedevicefeatures import FritzhomeDeviceFeatures
 from pyfritzhome.devicetypes.fritzhomeentitybase import FritzhomeEntityBase
 
 from .helper import Helper
@@ -28,6 +29,11 @@ class TestFritzhomeDeviceBase(object):
         assert device.has_switch
         assert device.has_temperature_sensor
         assert device.has_powermeter
+        assert device.supported_features == [
+            FritzhomeDeviceFeatures.POWER_METER,
+            FritzhomeDeviceFeatures.TEMPERATURE,
+            FritzhomeDeviceFeatures.SWITCH,
+        ]
 
     def test_device_init_present_false(self):
         self.mock.side_effect = [

--- a/tests/test_fritzhomedeviceblind.py
+++ b/tests/test_fritzhomedeviceblind.py
@@ -4,6 +4,7 @@
 from unittest.mock import MagicMock
 
 from pyfritzhome import Fritzhome
+from pyfritzhome.devicetypes.fritzhomedevicefeatures import FritzhomeDeviceFeatures
 
 from .helper import Helper
 
@@ -24,11 +25,18 @@ class TestFritzhomeDeviceBlind(object):
         device1 = self.fritz.get_device_by_ain("14276 1234567")
         assert device1.present
         assert not device1.tx_busy
+        assert device1.supported_features == [FritzhomeDeviceFeatures.HANFUN_DEVICE]
 
         device2 = self.fritz.get_device_by_ain("14276 1234567-1")
         assert device2.present
         assert not device2.tx_busy
         assert device2.endpositionsset
+        assert device2.supported_features == [
+            FritzhomeDeviceFeatures.ALARM,
+            FritzhomeDeviceFeatures.HANFUN_UNIT,
+            FritzhomeDeviceFeatures.LEVEL,
+            FritzhomeDeviceFeatures.BLIND,
+        ]
 
         assert device2.level == 252
         assert device2.levelpercentage == 99

--- a/tests/test_fritzhomedevicebutton.py
+++ b/tests/test_fritzhomedevicebutton.py
@@ -4,6 +4,7 @@
 from unittest.mock import MagicMock
 
 from pyfritzhome import Fritzhome
+from pyfritzhome.devicetypes.fritzhomedevicefeatures import FritzhomeDeviceFeatures
 
 from .helper import Helper
 
@@ -29,6 +30,10 @@ class TestFritzhomeDeviceButton(object):
         assert not device.battery_low
         assert device.battery_level == 100
         assert not device.tx_busy
+        assert device.supported_features == [
+            FritzhomeDeviceFeatures.BUTTON,
+            FritzhomeDeviceFeatures.TEMPERATURE,
+        ]
 
         button = device.get_button_by_ain("12345 0000001-1")
         assert button.name == "Taster Wohnzimmer: Oben rechts"

--- a/tests/test_fritzhomedevicelightbulb.py
+++ b/tests/test_fritzhomedevicelightbulb.py
@@ -4,6 +4,7 @@
 from unittest.mock import MagicMock
 
 from pyfritzhome import Fritzhome
+from pyfritzhome.devicetypes.fritzhomedevicefeatures import FritzhomeDeviceFeatures
 
 from .helper import Helper
 
@@ -26,6 +27,7 @@ class TestFritzhomeDeviceLightBulb(object):
         assert device.ain == "12345"
         assert device.fw_version == "34.10.16.16.009"
         assert device.present  # Lightbulb has power and is connected
+        assert device.supported_features == [FritzhomeDeviceFeatures.HANFUN_DEVICE]
 
         # Get sub-device
         device = self.fritz.get_device_by_ain("12345-1")
@@ -39,6 +41,13 @@ class TestFritzhomeDeviceLightBulb(object):
         assert device.saturation == 180
         assert device.color_temp is None
         assert device.name == "FRITZ!DECT 500 Büro"
+        assert device.supported_features == [
+            FritzhomeDeviceFeatures.LIGHTBULB,
+            FritzhomeDeviceFeatures.HANFUN_UNIT,
+            FritzhomeDeviceFeatures.SWITCHABLE,
+            FritzhomeDeviceFeatures.LEVEL,
+            FritzhomeDeviceFeatures.COLOR,
+        ]
 
     def test_device_init_non_color_bulb(self):
         self.mock.side_effect = [

--- a/tests/test_fritzhomedevicepowermeter.py
+++ b/tests/test_fritzhomedevicepowermeter.py
@@ -4,6 +4,7 @@
 from unittest.mock import MagicMock
 
 from pyfritzhome import Fritzhome
+from pyfritzhome.devicetypes.fritzhomedevicefeatures import FritzhomeDeviceFeatures
 
 from .helper import Helper
 
@@ -25,6 +26,11 @@ class TestFritzhomeDevicePowermeter(object):
         device = self.fritz.get_device_by_ain("08761 0000434")
 
         assert device.get_switch_power() == 18000
+        assert device.supported_features == [
+            FritzhomeDeviceFeatures.POWER_METER,
+            FritzhomeDeviceFeatures.TEMPERATURE,
+            FritzhomeDeviceFeatures.SWITCH,
+        ]
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
             {"ain": "08761 0000434", "switchcmd": "getswitchpower", "sid": None},

--- a/tests/test_fritzhomedeviceswitch.py
+++ b/tests/test_fritzhomedeviceswitch.py
@@ -4,6 +4,7 @@
 from unittest.mock import MagicMock
 
 from pyfritzhome import Fritzhome
+from pyfritzhome.devicetypes.fritzhomedevicefeatures import FritzhomeDeviceFeatures
 
 from .helper import Helper
 
@@ -27,6 +28,11 @@ class TestFritzhomeDeviceSwitch(object):
 
         assert device.get_switch_state()
         assert not device.get_switch_state()
+        assert device.supported_features == [
+            FritzhomeDeviceFeatures.POWER_METER,
+            FritzhomeDeviceFeatures.TEMPERATURE,
+            FritzhomeDeviceFeatures.SWITCH,
+        ]
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
             {"ain": "08761 0000434", "switchcmd": "getswitchstate", "sid": None},

--- a/tests/test_fritzhomedevicetemperature.py
+++ b/tests/test_fritzhomedevicetemperature.py
@@ -4,6 +4,7 @@
 from unittest.mock import MagicMock
 
 from pyfritzhome import Fritzhome
+from pyfritzhome.devicetypes.fritzhomedevicefeatures import FritzhomeDeviceFeatures
 
 from .helper import Helper
 
@@ -25,6 +26,10 @@ class TestFritzhomeDeviceTemperature(object):
         device = self.fritz.get_device_by_ain("12345")
 
         assert device.get_temperature() == 24.5
+        assert device.supported_features == [
+            FritzhomeDeviceFeatures.THERMOSTAT,
+            FritzhomeDeviceFeatures.TEMPERATURE,
+        ]
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
             {"ain": "12345", "switchcmd": "gettemperature", "sid": None},

--- a/tests/test_fritzhomedevicethermostat.py
+++ b/tests/test_fritzhomedevicethermostat.py
@@ -4,6 +4,7 @@
 from unittest.mock import MagicMock
 
 from pyfritzhome import Fritzhome, FritzhomeDevice
+from pyfritzhome.devicetypes.fritzhomedevicefeatures import FritzhomeDeviceFeatures
 
 from .helper import Helper
 
@@ -27,6 +28,10 @@ class TestFritzhomeDeviceThermostat(object):
         assert device.lock is None
         assert device.error_code is None
         assert device.battery_low is None
+        assert device.supported_features == [
+            FritzhomeDeviceFeatures.THERMOSTAT,
+            FritzhomeDeviceFeatures.TEMPERATURE,
+        ]
 
     def test_device_hkr_fw_03_54(self):
         self.mock.side_effect = [
@@ -36,6 +41,10 @@ class TestFritzhomeDeviceThermostat(object):
         self.fritz.update_devices()
         device = self.fritz.get_device_by_ain("23456")
         assert device.present
+        assert device.supported_features == [
+            FritzhomeDeviceFeatures.THERMOSTAT,
+            FritzhomeDeviceFeatures.TEMPERATURE,
+        ]
 
     def test_get_target_temperature(self):
         self.mock.side_effect = [

--- a/tests/test_fritzhomedevicethermostat_group.py
+++ b/tests/test_fritzhomedevicethermostat_group.py
@@ -4,6 +4,7 @@
 from unittest.mock import MagicMock
 
 from pyfritzhome import Fritzhome
+from pyfritzhome.devicetypes.fritzhomedevicefeatures import FritzhomeDeviceFeatures
 
 from .helper import Helper
 
@@ -25,3 +26,4 @@ class TestFritzhomeDeviceThermostat(object):
         assert group.has_thermostat
         assert group.is_group
         assert group.group_members == ["16", "17"]
+        assert group.supported_features == [FritzhomeDeviceFeatures.THERMOSTAT]

--- a/tests/test_fritzhometemplate.py
+++ b/tests/test_fritzhometemplate.py
@@ -4,6 +4,7 @@
 from unittest.mock import MagicMock
 
 from pyfritzhome import Fritzhome
+from pyfritzhome.devicetypes.fritzhomedevicefeatures import FritzhomeDeviceFeatures
 
 from .helper import Helper
 
@@ -33,6 +34,10 @@ class TestFritzhomeTemplate(object):
         assert not template.apply_level
         assert not template.apply_color
         assert not template.apply_dialhelper
+        assert template.supported_features == [
+            FritzhomeDeviceFeatures.THERMOSTAT,
+            FritzhomeDeviceFeatures.TEMPERATURE,
+        ]
 
     def test_template_with_single_device(self):
         template = self.fritz.get_template_by_ain("tmp0B32F7-1B0650234")


### PR DESCRIPTION
This adds a new property which returns a list of `FritzhomeDeviceFeatures` which are supported by the device.
Further the `UNKNOWN` has been removed since it was overlapping with the correct `BUTTON` feature.
This might be helpful in case of diagnostics.