### PR TITLE
add adaptive heating and boost support to thermostats

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,9 @@ Python Library to access AVM Fritz!Box homeautomation
 Tested Devices
 --------------
 * `FRITZ!Box 6490 Cable`_
+* `FRITZ!Box 7590`_
 * `FRITZ!DECT 200`_
+* `FRITZ!DECT 302`_
 * `FRITZ!DECT 440`_
 * `FRITZ!DECT 500`_
 * `Comet DECT`_
@@ -62,6 +64,10 @@ add a new user.
       comfort=22.0
       eco=19.0
       window=False
+      window_until=0
+      boost=None
+      boost_until=None
+      adaptive_heating_running=None
       summer=False
       holiday=False
     ##############################
@@ -182,9 +188,11 @@ References
 
 .. _Comet DECT: https://www.eurotronic.org/produkte/comet-dect.html
 .. _FRITZ!DECT 200: https://avm.de/produkte/fritzdect/fritzdect-200/
+.. _FRITZ!DECT 302: https://avm.de/produkte/fritzdect/fritzdect-302/
 .. _FRITZ!DECT 440: https://avm.de/produkte/fritzdect/fritzdect-440/
 .. _FRITZ!DECT 500: https://avm.de/produkte/fritzdect/fritzdect-500/
 .. _FRITZ!Box 6490 Cable: https://avm.de/produkte/fritzbox/fritzbox-6490-cable/
+.. _FRITZ!Box 7590: https://avm.de/produkte/fritzbox/fritzbox-7590/
 .. _Magenta Smarthome Tür-/Fensterkontakt optisch: https://www.smarthome.de/geraete/smarthome-tuer-fensterkontakt-optisch-weiss
 .. _RADEMACHER RolloTron DECT 1213: https://www.rademacher.de/shop/rollladen-sonnenschutz/elektrischer-gurtwickler/rollotron-dect-1213
 .. _Magenta Smarthome Zwischenstecker außen: https://www.smarthome.de/geraete/smarthome-zwischenstecker-aussen-schwarz

--- a/pyfritzhome/cli.py
+++ b/pyfritzhome/cli.py
@@ -58,6 +58,10 @@ def list_all(fritz, args):
             print("  comfort=%s" % device.comfort_temperature)
             print("  eco=%s" % device.eco_temperature)
             print("  window=%s" % device.window_open)
+            print("  window_until=%s" % device.window_open_endtime)
+            print("  boost=%s" % device.boost_active)
+            print("  boost_until=%s" % device.boost_active_endtime)
+            print("  adaptive_heating_running=%s" % device.adaptive_heating_running)
             print("  summer=%s" % device.summer_active)
             print("  holiday=%s" % device.holiday_active)
         if device.has_alarm:
@@ -117,6 +121,10 @@ def thermostat_set_target_temperature(fritz, args):
 def thermostat_set_window_open(fritz, args):
     """Command that sets the thermostats window state."""
     fritz.set_window_open(args.ain, args.timespan)
+
+def thermostat_set_boost_mode(fritz, args):
+    """Command that sets the thermostats into boost mode."""
+    fritz.set_boost_mode(args.ain, args.timespan)
 
 
 def switch_get(fritz, args):
@@ -282,6 +290,22 @@ def main(args=None):
         help="Open timespan in seconds (default=300s)",
     )
     subparser.set_defaults(func=thermostat_set_window_open)
+
+    # thermostat boost_mpde
+    subparser = _sub_switch.add_parser(
+        "set_boost_mode", help="activate the boost mode"
+    )
+    subparser.add_argument("ain", type=str, metavar="AIN", help="Actor Identification")
+    subparser.add_argument(
+        "timespan",
+        type=int,
+        choices=range(0, 86400),
+        metavar="TIMESPAN",
+        nargs="?",
+        default=300,
+        help="Boost timespan in seconds (default=300s)",
+    )
+    subparser.set_defaults(func=thermostat_set_boost_mode)
 
     # switch
     subparser = _sub.add_parser("switch", help="Switch commands")

--- a/pyfritzhome/devicetypes/fritzhomedevicethermostat.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicethermostat.py
@@ -66,10 +66,13 @@ class FritzhomeDeviceThermostat(FritzhomeDeviceBase):
             self.lock = self.get_node_value_as_int_as_bool(hkr_element, "lock")
             self.error_code = self.get_node_value_as_int(hkr_element, "errorcode")
             # keep battery values as fallback for Fritz!OS < 7.08
-            self.battery_low = self.get_node_value_as_int_as_bool(
-                hkr_element, "batterylow"
-            )
-            self.battery_level = int(self.get_node_value_as_int(hkr_element, "battery"))
+
+            if hkr_element.find("batterylow") is not None:
+                self.battery_low = self.get_node_value_as_int_as_bool(
+                    hkr_element, "batterylow"
+                )
+                self.battery_level = int(self.get_node_value_as_int(hkr_element, "battery"))
+
             self.window_open = self.get_node_value_as_int_as_bool(
                 hkr_element, "windowopenactiv"
             )
@@ -103,6 +106,7 @@ class FritzhomeDeviceThermostat(FritzhomeDeviceBase):
                 )
                 if self.boost_active_endtime < 0:
                     self.boost_active_endtime = 0
+
             if hkr_element.find("adaptiveHeatingActive") is not None:
                 self.adaptive_heating_active = self.get_node_value_as_int_as_bool(
                     hkr_element, "adaptiveHeatingActive"
@@ -110,6 +114,7 @@ class FritzhomeDeviceThermostat(FritzhomeDeviceBase):
                 self.adaptive_heating_running = self.get_node_value_as_int_as_bool(
                     hkr_element, "adaptiveHeatingRunning"
                 )
+
         except Exception:
             pass
 

--- a/pyfritzhome/devicetypes/fritzhomedevicethermostat.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicethermostat.py
@@ -22,6 +22,10 @@ class FritzhomeDeviceThermostat(FritzhomeDeviceBase):
     error_code = None
     window_open = None
     window_open_endtime = None
+    boost_active = None
+    boost_active_endtime = None
+    adaptive_heating_active = None
+    adaptive_heating_running = None
     summer_active = None
     holiday_active = None
     nextchange_endperiod = None
@@ -88,6 +92,24 @@ class FritzhomeDeviceThermostat(FritzhomeDeviceBase):
             self.nextchange_temperature = self.get_temp_from_node(
                 nextchange_element, "tchange"
             )
+
+            if hkr_element.find("boostactive") is not None:
+                self.boost_active = self.get_node_value_as_int_as_bool(
+                    hkr_element, "boostactive"
+                )
+                self.boost_active_endtime = (
+                    self.get_node_value_as_int(hkr_element, "boostactiveendtime")
+                    - time.time()
+                )
+                if self.boost_active_endtime < 0:
+                    self.boost_active_endtime = 0
+            if hkr_element.find("adaptiveHeatingActive") is not None:
+                self.adaptive_heating_active = self.get_node_value_as_int_as_bool(
+                    hkr_element, "adaptiveHeatingActive"
+                )
+                self.adaptive_heating_running = self.get_node_value_as_int_as_bool(
+                    hkr_element, "adaptiveHeatingRunning"
+                )
         except Exception:
             pass
 
@@ -106,6 +128,10 @@ class FritzhomeDeviceThermostat(FritzhomeDeviceBase):
     def set_window_open(self, seconds):
         """Set the thermostate to window open."""
         return self._fritz.set_window_open(self.ain, seconds)
+
+    def set_boost_mode(self, seconds):
+        """Set the thermostate into boost mode."""
+        return self._fritz.set_boost_mode(self.ain, seconds)
 
     def get_comfort_temperature(self):
         """Get the thermostate comfort temperature."""

--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -268,6 +268,14 @@ class Fritzhome(object):
             "sethkrwindowopen", ain=ain, param={"endtimestamp": endtimestamp}
         )
 
+    def set_boost_mode(self, ain, seconds):
+        """Set the thermostate to boost mode."""
+        endtimestamp = int(time.time() + seconds)
+
+        self._aha_request(
+            "sethkrboost", ain=ain, param={"endtimestamp": endtimestamp}
+        )
+
     def get_comfort_temperature(self, ain):
         """Get the thermostate comfort temperature."""
         return self._get_temperature(ain, "gethkrkomfort")

--- a/tests/responses/thermostat/device_hkr_fritzos_7_57.xml
+++ b/tests/responses/thermostat/device_hkr_fritzos_7_57.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+<devicelist version="1">
+    <device identifier="12345 6789012" id="25" functionbitmask="320" fwversion="05.13" manufacturer="AVM" productname="FRITZ!DECT 302">
+        <present>1</present>
+        <txbusy>0</txbusy>
+        <name>Wohnzimmer</name>
+        <battery>90</battery>
+        <batterylow>0</batterylow>
+        <temperature>
+            <celsius>265</celsius>
+            <offset>0</offset>
+        </temperature>
+        <hkr>
+            <tist>53</tist>
+            <tsoll>47</tsoll>
+            <absenk>36</absenk>
+            <komfort>44</komfort>
+            <lock>0</lock>
+            <devicelock>0</devicelock>
+            <errorcode>0</errorcode>
+            <windowopenactiv>0</windowopenactiv>
+            <windowopenactiveendtime>0</windowopenactiveendtime>
+            <boostactive>1</boostactive>
+            <boostactiveendtime>1704630842</boostactiveendtime>
+            <batterylow>0</batterylow>
+            <battery>90</battery>
+            <nextchange>
+                <endperiod>1704650400</endperiod>
+                <tchange>44</tchange>
+            </nextchange>
+            <summeractive>0</summeractive>
+            <holidayactive>0</holidayactive>
+            <adaptiveHeatingActive>1</adaptiveHeatingActive>
+            <adaptiveHeatingRunning>0</adaptiveHeatingRunning>
+        </hkr>
+    </device>
+</devicelist>

--- a/tests/test_fritzhome.py
+++ b/tests/test_fritzhome.py
@@ -217,3 +217,16 @@ class TestFritzhome(object):
                 "endtimestamp": 1000 + 25,
             },
         )
+
+    @patch("time.time", MagicMock(return_value=1000))
+    def test_set_boost_mode(self):
+        self.fritz.set_boost_mode("1", 25)
+        self.fritz._request.assert_called_with(
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {
+                "sid": None,
+                "ain": "1",
+                "switchcmd": "sethkrboost",
+                "endtimestamp": 1000 + 25,
+            },
+        )

--- a/tests/test_fritzhomedevicethermostat.py
+++ b/tests/test_fritzhomedevicethermostat.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from pyfritzhome import Fritzhome, FritzhomeDevice
 from pyfritzhome.devicetypes.fritzhomedevicefeatures import FritzhomeDeviceFeatures
@@ -196,6 +196,23 @@ class TestFritzhomeDeviceThermostat(object):
         self.fritz.update_devices()
         device = self.fritz.get_device_by_ain("12345")
         assert not device.window_open
+
+    @patch("time.time", MagicMock(return_value=1704630800))
+    def test_hkr_boost_mode(self):
+        self.mock.side_effect = [Helper.response("thermostat/device_hkr_fritzos_7_57")]
+
+        self.fritz.update_devices()
+        device = self.fritz.get_device_by_ain("12345 6789012")
+        assert device.boost_active is True
+        assert device.boost_active_endtime == 42
+
+    def test_hkr_adaptive_heating(self):
+        self.mock.side_effect = [Helper.response("thermostat/device_hkr_fritzos_7_57")]
+
+        self.fritz.update_devices()
+        device = self.fritz.get_device_by_ain("12345 6789012")
+        assert device.adaptive_heating_active is True
+        assert device.adaptive_heating_running is False
 
     def test_hkr_summer_active(self):
         self.mock.side_effect = [Helper.response("thermostat/device_hkr_fritzos_7")]

--- a/tests/test_fritzhomedevicethermostat_group.py
+++ b/tests/test_fritzhomedevicethermostat_group.py
@@ -27,3 +27,9 @@ class TestFritzhomeDeviceThermostat(object):
         assert group.is_group
         assert group.group_members == ["16", "17"]
         assert group.supported_features == [FritzhomeDeviceFeatures.THERMOSTAT]
+        assert group.adaptive_heating_active is True
+        assert group.adaptive_heating_running is False
+        assert group.boost_active is False
+        assert group.window_open is False
+        assert group.boost_active_endtime == 0
+        assert group.window_open_endtime == 0


### PR DESCRIPTION
This adds support for the boost feature introduced with Fritz!OS 7.20 and the adaptive heating feature introduced with Fritz!OS 7.39.

Information about these values with the associated end times is also added to the cli.

A bug with groups not having `batterylow` and `battery` in their element leading to and exception in https://github.com/hthiery/python-fritzhome/blob/dbd144291f5d6898a54906e9d3737877d2020f4c/pyfritzhome/devicetypes/fritzhomedevicethermostat.py#L65-L68 was also fixed.

I tested these changes only with the FRITZ!Box 7590 and multiple FRITZ!DECT 302.