### PR TITLE
Remove no more existing devices and templates from internal cache

### DIFF
--- a/pyfritzhome/cli.py
+++ b/pyfritzhome/cli.py
@@ -122,6 +122,7 @@ def thermostat_set_window_open(fritz, args):
     """Command that sets the thermostats window state."""
     fritz.set_window_open(args.ain, args.timespan)
 
+
 def thermostat_set_boost_mode(fritz, args):
     """Command that sets the thermostats into boost mode."""
     fritz.set_boost_mode(args.ain, args.timespan)
@@ -292,9 +293,7 @@ def main(args=None):
     subparser.set_defaults(func=thermostat_set_window_open)
 
     # thermostat boost_mpde
-    subparser = _sub_switch.add_parser(
-        "set_boost_mode", help="activate the boost mode"
-    )
+    subparser = _sub_switch.add_parser("set_boost_mode", help="activate the boost mode")
     subparser.add_argument("ain", type=str, metavar="AIN", help="Actor Identification")
     subparser.add_argument(
         "timespan",

--- a/pyfritzhome/devicetypes/fritzhomedevicethermostat.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicethermostat.py
@@ -71,7 +71,9 @@ class FritzhomeDeviceThermostat(FritzhomeDeviceBase):
                 self.battery_low = self.get_node_value_as_int_as_bool(
                     hkr_element, "batterylow"
                 )
-                self.battery_level = int(self.get_node_value_as_int(hkr_element, "battery"))
+                self.battery_level = int(
+                    self.get_node_value_as_int(hkr_element, "battery")
+                )
 
             self.window_open = self.get_node_value_as_int_as_bool(
                 hkr_element, "windowopenactiv"

--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -162,13 +162,14 @@ class Fritzhome(object):
         else:
             return "http://" + host
 
-    def update_devices(self):
+    def update_devices(self, ignore_removed=True):
         """Update the device."""
         _LOGGER.info("Updating Devices ...")
         if self._devices is None:
             self._devices = {}
 
-        for element in self.get_device_elements():
+        device_elements = self.get_device_elements()
+        for element in device_elements:
             if element.attrib["identifier"] in self._devices.keys():
                 _LOGGER.info(
                     "Updating already existing Device " + element.attrib["identifier"]
@@ -178,6 +179,15 @@ class Fritzhome(object):
                 _LOGGER.info("Adding new Device " + element.attrib["identifier"])
                 device = FritzhomeDevice(self, node=element)
                 self._devices[device.ain] = device
+
+        if not ignore_removed:
+            for identifier in list(self._devices.keys()):
+                if identifier not in [
+                    element.attrib["identifier"] for element in device_elements
+                ]:
+                    _LOGGER.info("Removing no more existing device " + identifier)
+                    self._devices.pop(identifier)
+
         return True
 
     def _get_listinfo_elements(self, entity_type):
@@ -280,9 +290,7 @@ class Fritzhome(object):
         """Set the thermostate to boost mode."""
         endtimestamp = int(time.time() + seconds)
 
-        self._aha_request(
-            "sethkrboost", ain=ain, param={"endtimestamp": endtimestamp}
-        )
+        self._aha_request("sethkrboost", ain=ain, param={"endtimestamp": endtimestamp})
 
     def get_comfort_temperature(self, ain):
         """Get the thermostate comfort temperature."""
@@ -407,13 +415,14 @@ class Fritzhome(object):
             return False
         return True
 
-    def update_templates(self):
+    def update_templates(self, ignore_removed=True):
         """Update the template."""
         _LOGGER.info("Updating Templates ...")
         if self._templates is None:
             self._templates = {}
 
-        for element in self.get_template_elements():
+        template_elements = self.get_template_elements()
+        for element in template_elements:
             if element.attrib["identifier"] in self._templates.keys():
                 _LOGGER.info(
                     "Updating already existing Template " + element.attrib["identifier"]
@@ -423,6 +432,15 @@ class Fritzhome(object):
                 _LOGGER.info("Adding new Template " + element.attrib["identifier"])
                 template = FritzhomeTemplate(self, node=element)
                 self._templates[template.ain] = template
+
+        if not ignore_removed:
+            for identifier in list(self._templates.keys()):
+                if identifier not in [
+                    element.attrib["identifier"] for element in template_elements
+                ]:
+                    _LOGGER.info("Removing no more existing template " + identifier)
+                    self._templates.pop(identifier)
+
         return True
 
     def get_template_elements(self):

--- a/tests/responses/base/device_list_removed_device.xml
+++ b/tests/responses/base/device_list_removed_device.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" ?>
+<devicelist version="1">
+    <device identifier="08761 0000434" id="17" functionbitmask="896" fwversion="03.33" manufacturer="AVM" productname="FRITZ!DECT 200">
+        <present>1</present>
+        <name>Steckdose</name>
+        <switch>
+            <state>1</state>
+            <mode>auto</mode>
+            <lock>0</lock>
+            <devicelock>0</devicelock>
+        </switch>
+        <powermeter>
+            <power>0</power>
+            <energy>707</energy>
+        </powermeter>
+        <temperature>
+            <celsius>285</celsius>
+            <offset>0</offset>
+        </temperature>
+    </device>
+    <device identifier="08761 1048079" id="16" functionbitmask="1280"
+    fwversion="03.44" manufacturer="AVM" productname="FRITZ!DECT Repeater 100">
+        <present>1</present>
+        <name>FRITZ!DECT Rep 100 #1</name>
+        <temperature>
+            <celsius>288</celsius>
+            <offset>0</offset>
+        </temperature>
+    </device>
+    <device identifier="11959 0171328" id="16" functionbitmask="320"
+    fwversion="03.54" manufacturer="AVM" productname="Comet DECT">
+        <present>1</present>
+        <name>Badezimmer</name>
+        <temperature>
+            <celsius>205</celsius>
+            <offset>-15</offset>
+        </temperature>
+        <hkr>
+            <tist>41</tist>
+            <tsoll>36</tsoll>
+            <absenk>36</absenk>
+            <komfort>42</komfort>
+            <lock>0</lock>
+            <devicelock>0</devicelock>
+            <errorcode>0</errorcode>
+            <batterylow>0</batterylow>
+            <nextchange>
+                <endperiod>1508342400</endperiod>
+                <tchange>42</tchange>
+            </nextchange>
+        </hkr>
+    </device>
+    <group identifier="65:3A:18-900" id="900" functionbitmask="512" fwversion="1.0" manufacturer="AVM" productname="">
+        <present>1</present>
+        <name>Gruppe</name>
+        <switch>
+            <state>1</state>
+            <mode>auto</mode>
+            <lock/>
+            <devicelock/>
+        </switch>
+        <groupinfo>
+            <masterdeviceid>0</masterdeviceid>
+            <members>17</members>
+        </groupinfo>
+    </group>
+</devicelist>

--- a/tests/responses/templates/template_list_removed_template.xml
+++ b/tests/responses/templates/template_list_removed_template.xml
@@ -1,0 +1,85 @@
+<templatelist version="1">
+    <!-- Base Data Tests -->
+    <template identifier="tmp0B32F7-1B0650682" id="60000" functionbitmask="320" applymask="0">
+        <name>Base Data</name>
+        <devices />
+        <applymask />
+    </template>
+
+    <!-- Device Tests -->
+    <template identifier="tmp0B32F7-1B0650234" id="60010" functionbitmask="0" applymask="0">
+        <name>One Device</name>
+        <devices>
+            <device identifier="08735 0525249" />
+        </devices>
+        <applymask />
+    </template>
+    <template identifier="tmp0B32F7-1C40A2B8A" id="60011" functionbitmask="0" applymask="0">
+        <name>Multiple Devices</name>
+        <devices>
+            <device identifier="08735 0316335" />
+            <device identifier="08735 0525249" />
+            <device identifier="08735 0526125" />
+            <device identifier="08735 0340143" />
+        </devices>
+        <applymask />
+    </template>
+
+    <!-- Applymask Tests -->
+    <template identifier="tmp0B32F7-1B064FA20" id="60020" functionbitmask="0" applymask="0">
+        <name>Apply Heating Summer Mode (Heating off)</name>
+        <devices />
+        <applymask>
+            <hkr_summer />
+        </applymask>
+    </template>
+    <template identifier="tmp0B32F7-1B064FA21" id="60021" functionbitmask="0" applymask="0">
+        <name>Apply Heating Target Temperature</name>
+        <devices />
+        <applymask>
+            <hkr_temperature />
+        </applymask>
+    </template>
+    <template identifier="tmp0B32F7-1B064FA22" id="60022" functionbitmask="0" applymask="0">
+        <name>Apply Heating Holiday Mode</name>
+        <devices />
+        <applymask>
+            <hkr_holidays />
+        </applymask>
+    </template>
+    <template identifier="tmp0B32F7-1B064FA23" id="60023" functionbitmask="0" applymask="0">
+        <name>Apply Heating Time Table</name>
+        <devices />
+        <applymask>
+            <hkr_time_table />
+        </applymask>
+    </template>
+    <template identifier="tmp0B32F7-1B064FA24" id="60024" functionbitmask="0" applymask="0">
+        <name>Apply Switch/Lamp/Actor manuel on/off Setting</name>
+        <devices />
+        <applymask>
+            <relay_manual />
+        </applymask>
+    </template>
+    <template identifier="tmp0B32F7-1B064FA25" id="60025" functionbitmask="0" applymask="0">
+        <name>Apply Switch/Lamp/Actor Automatic Time Table</name>
+        <devices />
+        <applymask>
+            <relay_automatic />
+        </applymask>
+    </template>
+    <template identifier="tmp0B32F7-1B064FA26" id="60026" functionbitmask="0" applymask="0">
+        <name>Apply Lamp/Blind Level</name>
+        <devices />
+        <applymask>
+            <level />
+        </applymask>
+    </template>
+    <template identifier="tmp0B32F7-1B064FA27" id="60027" functionbitmask="0" applymask="0">
+        <name>Apply Lamp Color</name>
+        <devices />
+        <applymask>
+            <color />
+        </applymask>
+    </template>
+</templatelist>

--- a/tests/test_fritzhome.py
+++ b/tests/test_fritzhome.py
@@ -234,7 +234,7 @@ class TestFritzhome(object):
         self.fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
             {
-                "sid": None,
+                "sid": "0000001",
                 "ain": "1",
                 "switchcmd": "sethkrboost",
                 "endtimestamp": 1000 + 25,

--- a/tests/test_fritzhomedevicebase.py
+++ b/tests/test_fritzhomedevicebase.py
@@ -98,6 +98,20 @@ class TestFritzhomeDeviceBase(object):
             {"ain": "08761 0000434", "switchcmd": "getswitchpresent", "sid": "0000001"},
         )
 
+    def test_device_removed(self):
+        self.mock.side_effect = [
+            Helper.response("base/device_list"),
+            Helper.response("base/device_list_removed_device"),
+            Helper.response("base/device_list_removed_device"),
+        ]
+
+        self.fritz.update_devices()
+        assert len(self.fritz.get_devices()) == 5
+        self.fritz.update_devices()
+        assert len(self.fritz.get_devices()) == 5
+        self.fritz.update_devices(ignore_removed=False)
+        assert len(self.fritz.get_devices()) == 4
+
     def test_device_and_unit_id(self):
         device = FritzhomeEntityBase()
 

--- a/tests/test_fritzhometemplate.py
+++ b/tests/test_fritzhometemplate.py
@@ -40,6 +40,20 @@ class TestFritzhomeTemplate(object):
             FritzhomeDeviceFeatures.TEMPERATURE,
         ]
 
+    def test_template_removed(self):
+        self.mock.side_effect = [
+            Helper.response("templates/template_list"),
+            Helper.response("templates/template_list_removed_template"),
+            Helper.response("templates/template_list_removed_template"),
+        ]
+
+        self.fritz.update_templates()
+        assert len(self.fritz.get_templates()) == 12
+        self.fritz.update_templates()
+        assert len(self.fritz.get_templates()) == 12
+        self.fritz.update_templates(ignore_removed=False)
+        assert len(self.fritz.get_templates()) == 11
+
     def test_template_with_single_device(self):
         template = self.fritz.get_template_by_ain("tmp0B32F7-1B0650234")
 


### PR DESCRIPTION
no more existing devices and templates will be removed from internal caches `self._devices` and `self._templates`.
With this we will be able to detect if a device or template has been removed and do necessary steps in consuming application (_eq. in homeassistant_) 