### PR TITLE
Add not logged in error

### DIFF
--- a/pyfritzhome/__init__.py
+++ b/pyfritzhome/__init__.py
@@ -1,6 +1,6 @@
 """Init file for pyfritzhome."""
 
-from .errors import InvalidError, LoginError
+from .errors import InvalidError, LoginError, NotLoggedInError
 from .fritzhome import Fritzhome
 from .fritzhomedevice import FritzhomeDevice
 
@@ -9,4 +9,5 @@ __all__ = (
     "FritzhomeDevice",
     "InvalidError",
     "LoginError",
+    "NotLoggedInError",
 )

--- a/pyfritzhome/errors.py
+++ b/pyfritzhome/errors.py
@@ -13,6 +13,14 @@ class LoginError(Exception):
         return 'login for user="{}" failed'.format(self.user)
 
 
+class NotLoggedInError(Exception):
+    """The NotLoggedInError Exception."""
+
+    def __str__(self):
+        """Return the error."""
+        return "not logged in, login before doing any requests."
+
+
 class InvalidError(Exception):
     """The InvalidError Exception."""
 

--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -80,13 +80,15 @@ class Fritzhome(object):
         salt2 = bytes.fromhex(challenge_parts[4])
         # Hash twice, once with static salt...
         # hash1 = hashlib.pbkdf2_hmac("sha256", password.encode(), salt1, iter1)
-        kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt1,
-                         iterations=iter1)
+        kdf = PBKDF2HMAC(
+            algorithm=hashes.SHA256(), length=32, salt=salt1, iterations=iter1
+        )
         hash1 = kdf.derive(password.encode())
         # Once with dynamic salt.
         # hash2 = hashlib.pbkdf2_hmac("sha256", hash1, salt2, iter2)
-        kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt2,
-                         iterations=iter2)
+        kdf = PBKDF2HMAC(
+            algorithm=hashes.SHA256(), length=32, salt=salt2, iterations=iter2
+        )
         hash2 = kdf.derive(hash1)
         return f"{challenge_parts[4]}${hash2.hex()}"
 
@@ -129,8 +131,7 @@ class Fritzhome(object):
                 time.sleep(blocktime)
             # PBKDF2 (FRITZ!OS 7.24 or later)
             if challenge.startswith("2$"):
-                secret = self._create_login_secrete_pbkdf2(challenge,
-                                                           self._password)
+                secret = self._create_login_secrete_pbkdf2(challenge, self._password)
             # fallback to MD5
             else:
                 secret = self._create_login_secret_md5(challenge, self._password)

--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 from requests import Session
 
-from .errors import InvalidError, LoginError
+from .errors import InvalidError, LoginError, NotLoggedInError
 from .fritzhomedevice import FritzhomeDevice
 from .fritzhomedevice import FritzhomeTemplate
 from typing import Dict
@@ -100,6 +100,12 @@ class Fritzhome(object):
     def _aha_request(self, cmd, ain=None, param=None, rf=str):
         """Send an AHA request."""
         url = self.get_prefixed_host() + "/webservices/homeautoswitch.lua"
+
+        _LOGGER.debug("self._sid:%s", self._sid)
+
+        if not self._sid:
+            raise NotLoggedInError
+
         params = {"switchcmd": cmd, "sid": self._sid}
         if param:
             params.update(param)
@@ -117,6 +123,7 @@ class Fritzhome(object):
     def login(self):
         """Login and get a valid session ID."""
         (sid, challenge, blocktime) = self._login_request()
+        _LOGGER.info("sid:%s, challenge:%s, blocktime:%s", sid, challenge, blocktime)
         if sid == "0000000000000000":
             if blocktime > 0:
                 time.sleep(blocktime)

--- a/tests/test_fritzhome.py
+++ b/tests/test_fritzhome.py
@@ -9,12 +9,13 @@ from pyfritzhome import Fritzhome, InvalidError, LoginError, NotLoggedInError
 
 from .helper import Helper
 
+
 class TestFritzhome(object):
     def setup_method(self):
         self.mock = MagicMock()
         self.fritz = Fritzhome("10.0.0.1", "user", "admin123")
         self.fritz._request = self.mock
-        self.fritz._sid="0000001"
+        self.fritz._sid = "0000001"
 
     def test_login_fail(self):
         self.mock.side_effect = [
@@ -56,8 +57,11 @@ class TestFritzhome(object):
         self.fritz.login()
         self.fritz._request.assert_called_with(
             "http://10.0.0.1/login_sid.lua?version=2",
-            {"username": "user", "response": "b9c232dea345233f5a893b2284931ac8$"
-             "2825c7fbd8cdbcbaf93ca2e8d0798c31cf38394469a9ce89365778dc9103ad82"},
+            {
+                "username": "user",
+                "response": "b9c232dea345233f5a893b2284931ac8$"
+                "2825c7fbd8cdbcbaf93ca2e8d0798c31cf38394469a9ce89365778dc9103ad82",
+            },
         )
 
     def test_logout(self):
@@ -68,7 +72,7 @@ class TestFritzhome(object):
         )
 
     def test_not_logged_in_error(self):
-        self.fritz._sid=None
+        self.fritz._sid = None
         with pytest.raises(NotLoggedInError):
             self.fritz.update_devices()
 

--- a/tests/test_fritzhome.py
+++ b/tests/test_fritzhome.py
@@ -73,8 +73,9 @@ class TestFritzhome(object):
 
     def test_not_logged_in_error(self):
         self.fritz._sid = None
-        with pytest.raises(NotLoggedInError):
+        with pytest.raises(NotLoggedInError) as ex:
             self.fritz.update_devices()
+        assert str(ex.value) == "not logged in, login before doing any requests."
 
     def test_aha_request(self):
         self.fritz._aha_request(cmd="testcmd")

--- a/tests/test_fritzhomedevicealarm.py
+++ b/tests/test_fritzhomedevicealarm.py
@@ -15,6 +15,7 @@ class TestFritzhomeDeviceAlarm(object):
         self.fritz = Fritzhome("10.0.0.1", "user", "pass")
         self.fritz._request = self.mock
         self.fritz._devices = {}
+        self.fritz._sid = "0000001"
 
     def test_device_alert_on(self):
         self.mock.side_effect = [

--- a/tests/test_fritzhomedevicebase.py
+++ b/tests/test_fritzhomedevicebase.py
@@ -16,6 +16,7 @@ class TestFritzhomeDeviceBase(object):
         self.fritz = Fritzhome("10.0.0.1", "user", "pass")
         self.fritz._request = self.mock
         self.fritz._devices = {}
+        self.fritz._sid = "0000001"
 
     def test_device_init(self):
         self.mock.side_effect = [Helper.response("base/device_list")]
@@ -94,7 +95,7 @@ class TestFritzhomeDeviceBase(object):
         assert not device.get_present()
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": "08761 0000434", "switchcmd": "getswitchpresent", "sid": None},
+            {"ain": "08761 0000434", "switchcmd": "getswitchpresent", "sid": "0000001"},
         )
 
     def test_device_and_unit_id(self):

--- a/tests/test_fritzhomedeviceblind.py
+++ b/tests/test_fritzhomedeviceblind.py
@@ -15,6 +15,7 @@ class TestFritzhomeDeviceBlind(object):
         self.fritz = Fritzhome("10.0.0.1", "user", "pass")
         self.fritz._request = self.mock
         self.fritz._devices = {}
+        self.fritz._sid = "0000001"
 
     def test_device_response(self):
         self.mock.side_effect = [
@@ -58,7 +59,7 @@ class TestFritzhomeDeviceBlind(object):
             "http://10.0.0.1/webservices/homeautoswitch.lua",
             {
                 "switchcmd": "setlevel",
-                "sid": None,
+                "sid": "0000001",
                 "ain": "14276 1234567-1",
                 "level": 100,
             },
@@ -78,7 +79,7 @@ class TestFritzhomeDeviceBlind(object):
             "http://10.0.0.1/webservices/homeautoswitch.lua",
             {
                 "switchcmd": "setlevelpercentage",
-                "sid": None,
+                "sid": "0000001",
                 "ain": "14276 1234567-1",
                 "level": 50,
             },
@@ -98,7 +99,7 @@ class TestFritzhomeDeviceBlind(object):
             "http://10.0.0.1/webservices/homeautoswitch.lua",
             {
                 "switchcmd": "setblind",
-                "sid": None,
+                "sid": "0000001",
                 "ain": "14276 1234567-1",
                 "target": "open",
             },
@@ -118,7 +119,7 @@ class TestFritzhomeDeviceBlind(object):
             "http://10.0.0.1/webservices/homeautoswitch.lua",
             {
                 "switchcmd": "setblind",
-                "sid": None,
+                "sid": "0000001",
                 "ain": "14276 1234567-1",
                 "target": "close",
             },
@@ -138,7 +139,7 @@ class TestFritzhomeDeviceBlind(object):
             "http://10.0.0.1/webservices/homeautoswitch.lua",
             {
                 "switchcmd": "setblind",
-                "sid": None,
+                "sid": "0000001",
                 "ain": "14276 1234567-1",
                 "target": "stop",
             },

--- a/tests/test_fritzhomedevicebutton.py
+++ b/tests/test_fritzhomedevicebutton.py
@@ -15,6 +15,7 @@ class TestFritzhomeDeviceButton(object):
         self.fritz = Fritzhome("10.0.0.1", "user", "pass")
         self.fritz._request = self.mock
         self.fritz._devices = {}
+        self.fritz._sid = "0000001"
 
     def test_button_fritzdect440(self):
         self.mock.side_effect = [

--- a/tests/test_fritzhomedevicelightbulb.py
+++ b/tests/test_fritzhomedevicelightbulb.py
@@ -15,6 +15,7 @@ class TestFritzhomeDeviceLightBulb(object):
         self.fritz = Fritzhome("10.0.0.1", "user", "pass")
         self.fritz._request = self.mock
         self.fritz._devices = {}
+        self.fritz._sid = "0000001"
 
     def test_device_init(self):
         self.mock.side_effect = [
@@ -211,7 +212,7 @@ class TestFritzhomeDeviceLightBulb(object):
             "http://10.0.0.1/webservices/homeautoswitch.lua",
             {
                 "switchcmd": "setcolor",
-                "sid": None,
+                "sid": "0000001",
                 "hue": 180,
                 "saturation": 200,
                 "duration": 0,
@@ -234,7 +235,7 @@ class TestFritzhomeDeviceLightBulb(object):
             "http://10.0.0.1/webservices/homeautoswitch.lua",
             {
                 "switchcmd": "setunmappedcolor",
-                "sid": None,
+                "sid": "0000001",
                 "hue": 180,
                 "saturation": 200,
                 "duration": 0,

--- a/tests/test_fritzhomedevicepowermeter.py
+++ b/tests/test_fritzhomedevicepowermeter.py
@@ -15,6 +15,7 @@ class TestFritzhomeDevicePowermeter(object):
         self.fritz = Fritzhome("10.0.0.1", "user", "pass")
         self.fritz._request = self.mock
         self.fritz._devices = {}
+        self.fritz._sid = "0000001"
 
     def test_get_switch_power(self):
         self.mock.side_effect = [
@@ -33,7 +34,7 @@ class TestFritzhomeDevicePowermeter(object):
         ]
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": "08761 0000434", "switchcmd": "getswitchpower", "sid": None},
+            {"ain": "08761 0000434", "switchcmd": "getswitchpower", "sid": "0000001"},
         )
 
     def test_get_switch_energy(self):
@@ -48,7 +49,7 @@ class TestFritzhomeDevicePowermeter(object):
         assert device.get_switch_energy() == 2000
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": "08761 0000434", "switchcmd": "getswitchenergy", "sid": None},
+            {"ain": "08761 0000434", "switchcmd": "getswitchenergy", "sid": "0000001"},
         )
 
     def test_get_switch_powermeter_properties(self):

--- a/tests/test_fritzhomedevicerepeater.py
+++ b/tests/test_fritzhomedevicerepeater.py
@@ -12,3 +12,4 @@ class TestFritzhomeDeviceRepeater(object):
         self.fritz = Fritzhome("10.0.0.1", "user", "pass")
         self.fritz._request = self.mock
         self.fritz._devices = {}
+        self.fritz._sid = "0000001"

--- a/tests/test_fritzhomedeviceswitch.py
+++ b/tests/test_fritzhomedeviceswitch.py
@@ -15,6 +15,7 @@ class TestFritzhomeDeviceSwitch(object):
         self.fritz = Fritzhome("10.0.0.1", "user", "pass")
         self.fritz._request = self.mock
         self.fritz._devices = {}
+        self.fritz._sid = "0000001"
 
     def test_get_switch_state(self):
         self.mock.side_effect = [
@@ -35,7 +36,7 @@ class TestFritzhomeDeviceSwitch(object):
         ]
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": "08761 0000434", "switchcmd": "getswitchstate", "sid": None},
+            {"ain": "08761 0000434", "switchcmd": "getswitchstate", "sid": "0000001"},
         )
 
     def test_set_switch_state_toggle(self):
@@ -50,7 +51,7 @@ class TestFritzhomeDeviceSwitch(object):
         device.set_switch_state_toggle()
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": "08761 0000434", "switchcmd": "setswitchtoggle", "sid": None},
+            {"ain": "08761 0000434", "switchcmd": "setswitchtoggle", "sid": "0000001"},
         )
 
     def test_set_switch_state_on(self):
@@ -65,7 +66,7 @@ class TestFritzhomeDeviceSwitch(object):
         device.set_switch_state_on()
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": "08761 0000434", "switchcmd": "setswitchon", "sid": None},
+            {"ain": "08761 0000434", "switchcmd": "setswitchon", "sid": "0000001"},
         )
 
     def test_set_switch_state_off(self):
@@ -80,5 +81,5 @@ class TestFritzhomeDeviceSwitch(object):
         device.set_switch_state_off()
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": "08761 0000434", "switchcmd": "setswitchoff", "sid": None},
+            {"ain": "08761 0000434", "switchcmd": "setswitchoff", "sid": "0000001"},
         )

--- a/tests/test_fritzhomedevicetemperature.py
+++ b/tests/test_fritzhomedevicetemperature.py
@@ -15,6 +15,7 @@ class TestFritzhomeDeviceTemperature(object):
         self.fritz = Fritzhome("10.0.0.1", "user", "pass")
         self.fritz._request = self.mock
         self.fritz._devices = {}
+        self.fritz._sid = "0000001"
 
     def test_get_temperature(self):
         self.mock.side_effect = [
@@ -32,5 +33,5 @@ class TestFritzhomeDeviceTemperature(object):
         ]
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": "12345", "switchcmd": "gettemperature", "sid": None},
+            {"ain": "12345", "switchcmd": "gettemperature", "sid": "0000001"},
         )

--- a/tests/test_fritzhomedevicethermostat.py
+++ b/tests/test_fritzhomedevicethermostat.py
@@ -15,7 +15,7 @@ class TestFritzhomeDeviceThermostat(object):
         self.fritz = Fritzhome("10.0.0.1", "user", "pass")
         self.fritz._request = self.mock
         self.fritz._devices = {}
-        self.fritz._sid="0000001"
+        self.fritz._sid = "0000001"
 
     def test_device_hkr_fw_03_50(self):
         self.mock.side_effect = [
@@ -166,7 +166,12 @@ class TestFritzhomeDeviceThermostat(object):
         device.set_hkr_state("on")
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": "12345", "switchcmd": "sethkrtsoll", "param": 254, "sid": "0000001"},
+            {
+                "ain": "12345",
+                "switchcmd": "sethkrtsoll",
+                "param": 254,
+                "sid": "0000001",
+            },
         )
 
     def test_hkr_set_state_off(self):
@@ -181,7 +186,12 @@ class TestFritzhomeDeviceThermostat(object):
         device.set_hkr_state("off")
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": "12345", "switchcmd": "sethkrtsoll", "param": 253, "sid": "0000001"},
+            {
+                "ain": "12345",
+                "switchcmd": "sethkrtsoll",
+                "param": 253,
+                "sid": "0000001",
+            },
         )
 
     def test_hkr_battery_level(self):

--- a/tests/test_fritzhomedevicethermostat.py
+++ b/tests/test_fritzhomedevicethermostat.py
@@ -15,6 +15,7 @@ class TestFritzhomeDeviceThermostat(object):
         self.fritz = Fritzhome("10.0.0.1", "user", "pass")
         self.fritz._request = self.mock
         self.fritz._devices = {}
+        self.fritz._sid="0000001"
 
     def test_device_hkr_fw_03_50(self):
         self.mock.side_effect = [
@@ -58,7 +59,7 @@ class TestFritzhomeDeviceThermostat(object):
         assert device.get_target_temperature() == 19.0
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": "12345", "switchcmd": "gethkrtsoll", "sid": None},
+            {"ain": "12345", "switchcmd": "gethkrtsoll", "sid": "0000001"},
         )
 
     def test_get_eco_temperature(self):
@@ -73,7 +74,7 @@ class TestFritzhomeDeviceThermostat(object):
         assert device.get_eco_temperature() == 20.0
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": "12345", "switchcmd": "gethkrabsenk", "sid": None},
+            {"ain": "12345", "switchcmd": "gethkrabsenk", "sid": "0000001"},
         )
 
     def test_get_comfort_temperature(self):
@@ -88,7 +89,7 @@ class TestFritzhomeDeviceThermostat(object):
         assert device.get_comfort_temperature() == 20.5
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": "12345", "switchcmd": "gethkrkomfort", "sid": None},
+            {"ain": "12345", "switchcmd": "gethkrkomfort", "sid": "0000001"},
         )
 
     def test_hkr_without_temperature_values(self):
@@ -165,7 +166,7 @@ class TestFritzhomeDeviceThermostat(object):
         device.set_hkr_state("on")
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": "12345", "switchcmd": "sethkrtsoll", "param": 254, "sid": None},
+            {"ain": "12345", "switchcmd": "sethkrtsoll", "param": 254, "sid": "0000001"},
         )
 
     def test_hkr_set_state_off(self):
@@ -180,7 +181,7 @@ class TestFritzhomeDeviceThermostat(object):
         device.set_hkr_state("off")
         device._fritz._request.assert_called_with(
             "http://10.0.0.1/webservices/homeautoswitch.lua",
-            {"ain": "12345", "switchcmd": "sethkrtsoll", "param": 253, "sid": None},
+            {"ain": "12345", "switchcmd": "sethkrtsoll", "param": 253, "sid": "0000001"},
         )
 
     def test_hkr_battery_level(self):

--- a/tests/test_fritzhomedevicethermostat_group.py
+++ b/tests/test_fritzhomedevicethermostat_group.py
@@ -15,6 +15,7 @@ class TestFritzhomeDeviceThermostat(object):
         self.fritz = Fritzhome("10.0.0.1", "user", "pass")
         self.fritz._request = self.mock
         self.fritz._devices = {}
+        self.fritz._sid = "0000001"
 
     def test_device_alert_on(self):
         self.mock.side_effect = [

--- a/tests/test_fritzhometemplate.py
+++ b/tests/test_fritzhometemplate.py
@@ -15,6 +15,7 @@ class TestFritzhomeTemplate(object):
         self.fritz = Fritzhome("10.0.0.1", "user", "pass")
         self.fritz._request = self.mock
         self.fritz._devices = {}
+        self.fritz._sid = "0000001"
 
         self.mock.side_effect = [Helper.response("templates/template_list")]
 


### PR DESCRIPTION
This will add a new exception called `NotLoggedInError`, which will be raised as soon as a aha request will be made without having a valid sid (_no login done before_).
Further some formatting improvements based on `black` has been automatically performed on changed files