### PR TITLE
Fix ci (run pypy39 on windows)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,26 @@ on: [push, pull_request]
 
 jobs:
   tests:
-    name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.9"]
+        include:
+          - python-version: "3.7"
+            os: ubuntu-latest
+          - python-version: "3.8"
+            os: ubuntu-latest
+          - python-version: "3.9"
+            os: ubuntu-latest
+          - python-version: "3.10"
+            os: ubuntu-latest
+          - python-version: "3.11"
+            os: ubuntu-latest
+          - python-version: "3.12"
+            os: ubuntu-latest
+          - python-version: "pypy3.9"
+            os: windows-latest
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This will run all python tests on `ubuntu-latest` and pypy on `windows-latests`, because `cryptography` does only provide wheels for pypy on windows, manylinux and macOS