### PR TITLE
Add wait_device_txbusy method

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,8 @@
 version: "2"
 checks:
+  argument-count:
+    config:
+      threshold: 5
   method-complexity:
     config:
       threshold: 13

--- a/pyfritzhome/devicetypes/fritzhomedeviceblind.py
+++ b/pyfritzhome/devicetypes/fritzhomedeviceblind.py
@@ -38,14 +38,14 @@ class FritzhomeDeviceBlind(FritzhomeDeviceBase):
         except Exception:
             pass
 
-    def set_blind_open(self):
+    def set_blind_open(self, wait=False):
         """Open the blind."""
-        self._fritz.set_blind_open(self.ain)
+        self._fritz.set_blind_open(self.ain, wait)
 
-    def set_blind_close(self):
+    def set_blind_close(self, wait=False):
         """Close the blind."""
-        self._fritz.set_blind_close(self.ain)
+        self._fritz.set_blind_close(self.ain, wait)
 
-    def set_blind_stop(self):
+    def set_blind_stop(self, wait=False):
         """Stop the blind."""
-        self._fritz.set_blind_stop(self.ain)
+        self._fritz.set_blind_stop(self.ain, wait)

--- a/pyfritzhome/devicetypes/fritzhomedevicelevel.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicelevel.py
@@ -48,10 +48,10 @@ class FritzhomeDeviceLevel(FritzhomeDeviceBase):
         """Get the level in percentage."""
         return self.levelpercentage
 
-    def set_level(self, level):
+    def set_level(self, level, wait=False):
         """Set the level."""
-        self._fritz.set_level(self.ain, level)
+        self._fritz.set_level(self.ain, level, wait)
 
-    def set_level_percentage(self, levelpercentage):
+    def set_level_percentage(self, levelpercentage, wait=False):
         """Set the level in percentage."""
-        self._fritz.set_level_percentage(self.ain, levelpercentage)
+        self._fritz.set_level_percentage(self.ain, levelpercentage, wait)

--- a/pyfritzhome/devicetypes/fritzhomedevicelightbulb.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicelightbulb.py
@@ -91,20 +91,20 @@ class FritzhomeDeviceLightBulb(FritzhomeDeviceBase):
                 # reset values after color mode changed
                 self.color_temp = None
 
-    def set_state_off(self):
+    def set_state_off(self, wait=False):
         """Switch light bulb off."""
         self.state = True
-        self._fritz.set_state_off(self.ain)
+        self._fritz.set_state_off(self.ain, wait)
 
-    def set_state_on(self):
+    def set_state_on(self, wait=False):
         """Switch light bulb on."""
         self.state = True
-        self._fritz.set_state_on(self.ain)
+        self._fritz.set_state_on(self.ain, wait)
 
-    def set_state_toggle(self):
+    def set_state_toggle(self, wait=False):
         """Toogle light bulb state."""
         self.state = True
-        self._fritz.set_state_toggle(self.ain)
+        self._fritz.set_state_toggle(self.ain, wait)
 
     def get_colors(self):
         """Get the supported colors."""
@@ -113,15 +113,15 @@ class FritzhomeDeviceLightBulb(FritzhomeDeviceBase):
         else:
             return {}
 
-    def set_color(self, hsv, duration=0):
+    def set_color(self, hsv, duration=0, wait=False):
         """Set HSV color."""
         if self.has_color:
-            self._fritz.set_color(self.ain, hsv, duration, True)
+            self._fritz.set_color(self.ain, hsv, duration, True, wait)
 
-    def set_unmapped_color(self, hsv, duration=0):
+    def set_unmapped_color(self, hsv, duration=0, wait=False):
         """Set unmapped HSV color (Free color selection)."""
         if self.has_color:
-            self._fritz.set_color(self.ain, hsv, duration, False)
+            self._fritz.set_color(self.ain, hsv, duration, False, wait)
 
     def get_color_temps(self):
         """Get the supported color temperatures energy."""
@@ -130,7 +130,7 @@ class FritzhomeDeviceLightBulb(FritzhomeDeviceBase):
         else:
             return []
 
-    def set_color_temp(self, temperature, duration=0):
+    def set_color_temp(self, temperature, duration=0, wait=False):
         """Set white color temperature."""
         if self.has_color:
-            self._fritz.set_color_temp(self.ain, temperature, duration)
+            self._fritz.set_color_temp(self.ain, temperature, duration, wait)

--- a/pyfritzhome/devicetypes/fritzhomedeviceswitch.py
+++ b/pyfritzhome/devicetypes/fritzhomedeviceswitch.py
@@ -68,14 +68,14 @@ class FritzhomeDeviceSwitch(FritzhomeDeviceBase):
         """Get the switch state."""
         return self._fritz.get_switch_state(self.ain)
 
-    def set_switch_state_on(self):
+    def set_switch_state_on(self, wait=False):
         """Set the switch state to on."""
-        return self._fritz.set_switch_state_on(self.ain)
+        return self._fritz.set_switch_state_on(self.ain, wait)
 
-    def set_switch_state_off(self):
+    def set_switch_state_off(self, wait=False):
         """Set the switch state to off."""
-        return self._fritz.set_switch_state_off(self.ain)
+        return self._fritz.set_switch_state_off(self.ain, wait)
 
-    def set_switch_state_toggle(self):
+    def set_switch_state_toggle(self, wait=False):
         """Toggle the switch state."""
-        return self._fritz.set_switch_state_toggle(self.ain)
+        return self._fritz.set_switch_state_toggle(self.ain, wait)

--- a/pyfritzhome/devicetypes/fritzhomedevicethermostat.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicethermostat.py
@@ -132,17 +132,17 @@ class FritzhomeDeviceThermostat(FritzhomeDeviceBase):
         """Get the thermostate target temperature."""
         return self._fritz.get_target_temperature(self.ain)
 
-    def set_target_temperature(self, temperature):
+    def set_target_temperature(self, temperature, wait=False):
         """Set the thermostate target temperature."""
-        return self._fritz.set_target_temperature(self.ain, temperature)
+        return self._fritz.set_target_temperature(self.ain, temperature, wait)
 
-    def set_window_open(self, seconds):
+    def set_window_open(self, seconds, wait=False):
         """Set the thermostate to window open."""
-        return self._fritz.set_window_open(self.ain, seconds)
+        return self._fritz.set_window_open(self.ain, seconds, wait)
 
-    def set_boost_mode(self, seconds):
+    def set_boost_mode(self, seconds, wait=False):
         """Set the thermostate into boost mode."""
-        return self._fritz.set_boost_mode(self.ain, seconds)
+        return self._fritz.set_boost_mode(self.ain, seconds, wait)
 
     def get_comfort_temperature(self):
         """Get the thermostate comfort temperature."""
@@ -164,7 +164,7 @@ class FritzhomeDeviceThermostat(FritzhomeDeviceBase):
         except KeyError:
             return "manual"
 
-    def set_hkr_state(self, state):
+    def set_hkr_state(self, state, wait=False):
         """Set the state of the thermostat.
 
         Possible values for state are: 'on', 'off', 'comfort', 'eco'.
@@ -179,4 +179,4 @@ class FritzhomeDeviceThermostat(FritzhomeDeviceBase):
         except KeyError:
             return
 
-        self.set_target_temperature(value)
+        self.set_target_temperature(value, wait)

--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -197,6 +197,17 @@ class Fritzhome(object):
         _LOGGER.debug(dom)
         return dom.findall("*")
 
+    def wait_device_txbusy(self, ain, retries=10):
+        """Wait for device to finish command execution."""
+        for _ in range(retries):
+            plain = self.get_device_infos(ain)
+            dom = ElementTree.fromstring(plain)
+            txbusy = dom.findall("txbusy")
+            if txbusy[0].text == "0":
+                return True
+            time.sleep(0.2)
+        return False
+
     def get_device_elements(self):
         """Get the DOM elements for the device list."""
         return self._get_listinfo_elements("device")
@@ -223,6 +234,10 @@ class Fritzhome(object):
         """Return a device specified by the AIN."""
         return self.get_devices_as_dict()[ain]
 
+    def get_device_infos(self, ain):
+        """Get the device infos."""
+        return self._aha_request("getdeviceinfos", ain=ain)
+
     def get_device_present(self, ain):
         """Get the device presence."""
         return self._aha_request("getswitchpresent", ain=ain, rf=bool)
@@ -235,17 +250,23 @@ class Fritzhome(object):
         """Get the switch state."""
         return self._aha_request("getswitchstate", ain=ain, rf=bool)
 
-    def set_switch_state_on(self, ain):
+    def set_switch_state_on(self, ain, wait=False):
         """Set the switch to on state."""
-        return self._aha_request("setswitchon", ain=ain, rf=bool)
+        result = self._aha_request("setswitchon", ain=ain, rf=bool)
+        wait and self.wait_device_txbusy(ain)
+        return result
 
-    def set_switch_state_off(self, ain):
+    def set_switch_state_off(self, ain, wait=False):
         """Set the switch to off state."""
-        return self._aha_request("setswitchoff", ain=ain, rf=bool)
+        result = self._aha_request("setswitchoff", ain=ain, rf=bool)
+        wait and self.wait_device_txbusy(ain)
+        return result
 
-    def set_switch_state_toggle(self, ain):
+    def set_switch_state_toggle(self, ain, wait=False):
         """Toggle the switch state."""
-        return self._aha_request("setswitchtoggle", ain=ain, rf=bool)
+        result = self._aha_request("setswitchtoggle", ain=ain, rf=bool)
+        wait and self.wait_device_txbusy(ain)
+        return result
 
     def get_switch_power(self, ain):
         """Get the switch power consumption."""
@@ -267,7 +288,7 @@ class Fritzhome(object):
         """Get the thermostate target temperature."""
         return self._get_temperature(ain, "gethkrtsoll")
 
-    def set_target_temperature(self, ain, temperature):
+    def set_target_temperature(self, ain, temperature, wait=False):
         """Set the thermostate target temperature."""
         temp = int(16 + ((float(temperature) - 8) * 2))
 
@@ -277,20 +298,23 @@ class Fritzhome(object):
             temp = 254
 
         self._aha_request("sethkrtsoll", ain=ain, param={"param": temp})
+        wait and self.wait_device_txbusy(ain)
 
-    def set_window_open(self, ain, seconds):
+    def set_window_open(self, ain, seconds, wait=False):
         """Set the thermostate target temperature."""
         endtimestamp = int(time.time() + seconds)
 
         self._aha_request(
             "sethkrwindowopen", ain=ain, param={"endtimestamp": endtimestamp}
         )
+        wait and self.wait_device_txbusy(ain)
 
-    def set_boost_mode(self, ain, seconds):
+    def set_boost_mode(self, ain, seconds, wait=False):
         """Set the thermostate to boost mode."""
         endtimestamp = int(time.time() + seconds)
 
         self._aha_request("sethkrboost", ain=ain, param={"endtimestamp": endtimestamp})
+        wait and self.wait_device_txbusy(ain)
 
     def get_comfort_temperature(self, ain):
         """Get the thermostate comfort temperature."""
@@ -307,19 +331,22 @@ class Fritzhome(object):
 
     # Lightbulb-related commands
 
-    def set_state_off(self, ain):
+    def set_state_off(self, ain, wait=False):
         """Set the switch/actuator/lightbulb to on state."""
         self._aha_request("setsimpleonoff", ain=ain, param={"onoff": 0})
+        wait and self.wait_device_txbusy(ain)
 
-    def set_state_on(self, ain):
+    def set_state_on(self, ain, wait=False):
         """Set the switch/actuator/lightbulb to on state."""
         self._aha_request("setsimpleonoff", ain=ain, param={"onoff": 1})
+        wait and self.wait_device_txbusy(ain)
 
-    def set_state_toggle(self, ain):
+    def set_state_toggle(self, ain, wait=False):
         """Toggle the switch/actuator/lightbulb state."""
         self._aha_request("setsimpleonoff", ain=ain, param={"onoff": 2})
+        wait and self.wait_device_txbusy(ain)
 
-    def set_level(self, ain, level):
+    def set_level(self, ain, level, wait=False):
         """Set level/brightness/height in interval [0,255]."""
         if level < 0:
             level = 0  # 0%
@@ -327,8 +354,9 @@ class Fritzhome(object):
             level = 255  # 100 %
 
         self._aha_request("setlevel", ain=ain, param={"level": int(level)})
+        wait and self.wait_device_txbusy(ain)
 
-    def set_level_percentage(self, ain, level):
+    def set_level_percentage(self, ain, level, wait=False):
         """Set level/brightness/height in interval [0,100]."""
         if level < 0:
             level = 0
@@ -336,6 +364,7 @@ class Fritzhome(object):
             level = 100
 
         self._aha_request("setlevelpercentage", ain=ain, param={"level": int(level)})
+        wait and self.wait_device_txbusy(ain)
 
     def _get_colordefaults(self, ain):
         plain = self._aha_request("getcolordefaults", ain=ain)
@@ -353,7 +382,7 @@ class Fritzhome(object):
             colors[name] = values
         return colors
 
-    def set_color(self, ain, hsv, duration=0, mapped=True):
+    def set_color(self, ain, hsv, duration=0, mapped=True, wait=False):
         """Set hue and saturation.
 
         hsv: HUE colorspace element obtained from get_colors()
@@ -369,6 +398,7 @@ class Fritzhome(object):
         else:
             # undocumented API method for free color selection
             self._aha_request("setunmappedcolor", ain=ain, param=params)
+        wait and self.wait_device_txbusy(ain)
 
     def get_color_temps(self, ain):
         """Get temperatures supported by this lightbulb."""
@@ -378,7 +408,7 @@ class Fritzhome(object):
             temperatures.append(temp.get("value"))
         return temperatures
 
-    def set_color_temp(self, ain, temperature, duration=0):
+    def set_color_temp(self, ain, temperature, duration=0, wait=False):
         """Set color temperature.
 
         temperature: temperature element obtained from get_temperatures()
@@ -386,23 +416,27 @@ class Fritzhome(object):
         """
         params = {"temperature": int(temperature), "duration": int(duration) * 10}
         self._aha_request("setcolortemperature", ain=ain, param=params)
+        wait and self.wait_device_txbusy(ain)
 
     # blinds
     # states: open, close, stop
     def _set_blind_state(self, ain, state):
         self._aha_request("setblind", ain=ain, param={"target": state})
 
-    def set_blind_open(self, ain):
+    def set_blind_open(self, ain, wait=False):
         """Set the blind state to open."""
         self._set_blind_state(ain, "open")
+        wait and self.wait_device_txbusy(ain)
 
-    def set_blind_close(self, ain):
+    def set_blind_close(self, ain, wait=False):
         """Set the blind state to close."""
         self._set_blind_state(ain, "close")
+        wait and self.wait_device_txbusy(ain)
 
-    def set_blind_stop(self, ain):
+    def set_blind_stop(self, ain, wait=False):
         """Set the blind state to stop."""
         self._set_blind_state(ain, "stop")
+        wait and self.wait_device_txbusy(ain)
 
     # Template-related commands
 

--- a/tests/responses/base/device_not_txbusy.xml
+++ b/tests/responses/base/device_not_txbusy.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<device functionbitmask="320" fwversion="03.54" id="18" identifier="11960 0089208" manufacturer="AVM" productname="Comet DECT">
+    <present>0</present>
+    <txbusy>0</txbusy>
+    <name>Kitchen</name>
+    <temperature>
+        <celsius/>
+        <offset/>
+    </temperature>
+    <hkr>
+        <tist/>
+        <tsoll/>
+        <absenk/>
+        <komfort/>
+        <lock/>
+        <devicelock/>
+        <errorcode>0</errorcode>
+        <batterylow>0</batterylow>
+        <nextchange>
+            <endperiod>0</endperiod>
+            <tchange>255</tchange>
+        </nextchange>
+    </hkr>
+</device>

--- a/tests/responses/base/device_txbusy.xml
+++ b/tests/responses/base/device_txbusy.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<device functionbitmask="320" fwversion="03.54" id="18" identifier="11960 0089208" manufacturer="AVM" productname="Comet DECT">
+    <present>0</present>
+    <txbusy>1</txbusy>
+    <name>Kitchen</name>
+    <temperature>
+        <celsius/>
+        <offset/>
+    </temperature>
+    <hkr>
+        <tist/>
+        <tsoll/>
+        <absenk/>
+        <komfort/>
+        <lock/>
+        <devicelock/>
+        <errorcode>0</errorcode>
+        <batterylow>0</batterylow>
+        <nextchange>
+            <endperiod>0</endperiod>
+            <tchange>255</tchange>
+        </nextchange>
+    </hkr>
+</device>

--- a/tests/test_fritzhome.py
+++ b/tests/test_fritzhome.py
@@ -215,6 +215,103 @@ class TestFritzhome(object):
             {"sid": "0000001", "ain": "1", "switchcmd": "sethkrtsoll", "param": 254},
         )
 
+    def test_set_state(self):
+        self.fritz.set_state_off("1")
+        self.fritz._request.assert_called_with(
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {"switchcmd": "setsimpleonoff", "sid": "0000001", "onoff": 0, "ain": "1"},
+        )
+
+        self.fritz.set_state_on("1")
+        self.fritz._request.assert_called_with(
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {"switchcmd": "setsimpleonoff", "sid": "0000001", "onoff": 1, "ain": "1"},
+        )
+
+        self.fritz.set_state_toggle("1")
+        self.fritz._request.assert_called_with(
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {"switchcmd": "setsimpleonoff", "sid": "0000001", "onoff": 2, "ain": "1"},
+        )
+
+    def test_set_level(self):
+        self.fritz.set_level("1", 10)
+        self.fritz._request.assert_called_with(
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {"switchcmd": "setlevel", "sid": "0000001", "level": 10, "ain": "1"},
+        )
+
+        self.fritz.set_level("1", -1)
+        self.fritz._request.assert_called_with(
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {"switchcmd": "setlevel", "sid": "0000001", "level": 0, "ain": "1"},
+        )
+
+        self.fritz.set_level("1", 256)
+        self.fritz._request.assert_called_with(
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {"switchcmd": "setlevel", "sid": "0000001", "level": 255, "ain": "1"},
+        )
+
+    def test_set_level_percentage(self):
+        self.fritz.set_level_percentage("1", 10)
+        self.fritz._request.assert_called_with(
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {
+                "switchcmd": "setlevelpercentage",
+                "sid": "0000001",
+                "level": 10,
+                "ain": "1",
+            },
+        )
+
+        self.fritz.set_level_percentage("1", -1)
+        self.fritz._request.assert_called_with(
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {
+                "switchcmd": "setlevelpercentage",
+                "sid": "0000001",
+                "level": 0,
+                "ain": "1",
+            },
+        )
+
+        self.fritz.set_level_percentage("1", 101)
+        self.fritz._request.assert_called_with(
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {
+                "switchcmd": "setlevelpercentage",
+                "sid": "0000001",
+                "level": 100,
+                "ain": "1",
+            },
+        )
+
+    def test_set_color_temp(self):
+        self.fritz.set_color_temp("1", 3500)
+        self.fritz._request.assert_called_with(
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {
+                "switchcmd": "setcolortemperature",
+                "sid": "0000001",
+                "temperature": 3500,
+                "duration": 0,
+                "ain": "1",
+            },
+        )
+
+        self.fritz.set_color_temp("1", 3500, 2)
+        self.fritz._request.assert_called_with(
+            "http://10.0.0.1/webservices/homeautoswitch.lua",
+            {
+                "switchcmd": "setcolortemperature",
+                "sid": "0000001",
+                "temperature": 3500,
+                "duration": 20,
+                "ain": "1",
+            },
+        )
+
     @patch("time.time", MagicMock(return_value=1000))
     def test_set_window_open(self):
         self.fritz.set_window_open("1", 25)
@@ -240,3 +337,19 @@ class TestFritzhome(object):
                 "endtimestamp": 1000 + 25,
             },
         )
+
+    def test_wait_tx_busy(self):
+        self.mock.side_effect = [
+            Helper.response("base/device_txbusy"),
+            Helper.response("base/device_not_txbusy"),
+        ]
+
+        assert self.fritz.wait_device_txbusy("11960 0089208")
+
+    def test_wait_tx_busy_failed(self):
+        self.mock.side_effect = [
+            Helper.response("base/device_txbusy"),
+            Helper.response("base/device_txbusy"),
+        ]
+
+        assert not self.fritz.wait_device_txbusy("11960 0089208", 1)


### PR DESCRIPTION
With this we can wait on every `set_` method afterwards for `txbusy` becoming `0` again, which indicates, that the command execution has been finished. This will most properly affect stationary powered devices (_eq. Fritz!DECT 200 plugs or Fritz!DECT 500 bulbs_), since they start the command execution immediately, while for battery powered devices (_eq. Fritz!DECT 301 thermostats_) the commands are queued in the Fritzbox and executed as soon as the devices wake up, therefore their `txbusy` is `0` right away, until they wake up.
To avoid a breaking change, the wait method is disabled per default for any `set_` method.

reference: https://github.com/home-assistant/core/issues/113749