### PR TITLE
Fix AVM DECT440 on older FRITZ!OS

### DIFF
--- a/pyfritzhome/devicetypes/fritzhomeentitybase.py
+++ b/pyfritzhome/devicetypes/fritzhomeentitybase.py
@@ -42,6 +42,12 @@ class FritzhomeEntityBase(ABC):
         self.ain = node.attrib["identifier"]
         self._functionsbitmask = int(node.attrib["functionbitmask"])
 
+        # Workaround for broken AVM FRITZ!DECT 440 in FRITZ!OS < 7.20
+        if (node.attrib["manufacturer"] == "AVM"
+            and node.attrib["productname"] == "FRITZ!DECT 440"
+            and node.find("humidity") is None):
+            self._functionsbitmask &= ~int(FritzhomeDeviceFeatures.HUMIDITY)
+
         self.name = node.findtext("name").strip()
 
         self.supported_features = []


### PR DESCRIPTION
On FRITZ!OS < 7.20, the DECT440 is reported with `functionsbitmask` containing the `HUMIDITY` feature, but the device-node does not actually contain that element. So patch the `functionsbitmask` if that situation is detected.