### PR TITLE
Check if a lightbulb has fullcolorsupport

### DIFF
--- a/pyfritzhome/devicetypes/fritzhomedevicelightbulb.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicelightbulb.py
@@ -21,7 +21,7 @@ class FritzhomeDeviceLightBulb(FritzhomeDeviceBase):
     color_temp = None
     color_mode = None
     supported_color_mode = None
-    fullcolorsupport = None
+    fullcolorsupport: bool = False
 
     def _update_from_node(self, node):
         super()._update_from_node(node)
@@ -60,8 +60,8 @@ class FritzhomeDeviceLightBulb(FritzhomeDeviceBase):
                     "supported_modes"
                 )
 
-                self.fullcolorsupport = colorcontrol_element.attrib.get(
-                    "fullcolorsupport"
+                self.fullcolorsupport = bool(
+                    colorcontrol_element.attrib.get("fullcolorsupport")
                 )
 
             except ValueError:

--- a/pyfritzhome/devicetypes/fritzhomedevicelightbulb.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicelightbulb.py
@@ -1,4 +1,5 @@
 """The light bulb device class."""
+
 # -*- coding: utf-8 -*-
 
 import logging
@@ -20,6 +21,7 @@ class FritzhomeDeviceLightBulb(FritzhomeDeviceBase):
     color_temp = None
     color_mode = None
     supported_color_mode = None
+    fullcolorsupport = None
 
     def _update_from_node(self, node):
         super()._update_from_node(node)
@@ -56,6 +58,10 @@ class FritzhomeDeviceLightBulb(FritzhomeDeviceBase):
 
                 self.supported_color_mode = colorcontrol_element.attrib.get(
                     "supported_modes"
+                )
+
+                self.fullcolorsupport = colorcontrol_element.attrib.get(
+                    "fullcolorsupport"
                 )
 
             except ValueError:
@@ -120,7 +126,7 @@ class FritzhomeDeviceLightBulb(FritzhomeDeviceBase):
 
     def set_unmapped_color(self, hsv, duration=0, wait=False):
         """Set unmapped HSV color (Free color selection)."""
-        if self.has_color:
+        if self.has_color and self.fullcolorsupport:
             self._fritz.set_color(self.ain, hsv, duration, False, wait)
 
     def get_color_temps(self):

--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -396,7 +396,7 @@ class Fritzhome(object):
         if mapped:
             self._aha_request("setcolor", ain=ain, param=params)
         else:
-            # undocumented API method for free color selection
+            # available since Fritz!OS 7.39
             self._aha_request("setunmappedcolor", ain=ain, param=params)
         wait and self.wait_device_txbusy(ain)
 

--- a/tests/test_fritzhomedevicelightbulb.py
+++ b/tests/test_fritzhomedevicelightbulb.py
@@ -67,7 +67,7 @@ class TestFritzhomeDeviceLightBulb(object):
         device = self.fritz.get_device_by_ain("12701 0072784-1")
         assert device.has_lightbulb
         assert device.has_level
-        assert device.fullcolorsupport is False
+        assert not device.fullcolorsupport
         assert device.state  # Lightbulb is switched on
         assert device.name == "Telekom White Dimmable Bulb"
 

--- a/tests/test_fritzhomedevicelightbulb.py
+++ b/tests/test_fritzhomedevicelightbulb.py
@@ -38,6 +38,7 @@ class TestFritzhomeDeviceLightBulb(object):
         assert device.state  # Lightbulb is switched on
         assert device.color_mode == "1"
         assert device.supported_color_mode == "5"
+        assert device.fullcolorsupport
         assert device.hue == 358
         assert device.saturation == 180
         assert device.color_temp is None
@@ -87,6 +88,7 @@ class TestFritzhomeDeviceLightBulb(object):
         assert device.state  # Lightbulb is switched on
         assert device.color_mode == "4"
         assert device.supported_color_mode == "5"
+        assert device.fullcolorsupport
         assert device.hue is None
         assert device.saturation is None
         assert device.color_temp == 2800

--- a/tests/test_fritzhomedevicelightbulb.py
+++ b/tests/test_fritzhomedevicelightbulb.py
@@ -67,6 +67,7 @@ class TestFritzhomeDeviceLightBulb(object):
         device = self.fritz.get_device_by_ain("12701 0072784-1")
         assert device.has_lightbulb
         assert device.has_level
+        assert device.fullcolorsupport is False
         assert device.state  # Lightbulb is switched on
         assert device.name == "Telekom White Dimmable Bulb"
 


### PR DESCRIPTION
If `fullcolorsupport` is set, we can use `setunmappedcolor` for free color selection. This was not documented at the time I implemented the free color selection.