### PR TITLE
Run tests on python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ jobs:
     strategy:
       matrix:
         include:
+          - python-version: "3.7"
+            os: ubuntu-20.04
+          - python-version: "3.8"
+            os: ubuntu-20.04
           - python-version: "3.9"
             os: ubuntu-latest
           - python-version: "3.10"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.7"
-            os: ubuntu-latest
-          - python-version: "3.8"
-            os: ubuntu-latest
           - python-version: "3.9"
             os: ubuntu-latest
           - python-version: "3.10"
@@ -21,6 +17,8 @@ jobs:
           - python-version: "3.11"
             os: ubuntu-latest
           - python-version: "3.12"
+            os: ubuntu-latest
+          - python-version: "3.13"
             os: ubuntu-latest
           - python-version: "pypy3.9"
             os: windows-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,12 +13,11 @@ license_file = LICENSE
 classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,8 @@ license_file = LICENSE
 classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11


### PR DESCRIPTION
Run tests on python 3.13 and drop python 3.7 and 3.8, both are EOL.