### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Install pypa/build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,10 @@ jobs:
             os: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -57,7 +57,7 @@ jobs:
         run: pytest --cov=pyfritzhome --cov-report=lcov
 
       - name: Coveralls Parallel
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@main
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ matrix.test_number }}
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@main
         with:
           github-token: ${{ secrets.github_token }}
           parallel-finished: true

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Python Library to access AVM Fritz!Box homeautomation
 =====================================================
 
-|BuildStatus| |PypiVersion| |PyPiPythonVersions| |Coveralls| |CodeClimate| |Codacy|
+|BuildStatus| |PypiVersion| |PyPiPythonVersions| |Coveralls| |CodeClimate|
 
 Tested Devices
 --------------
@@ -183,8 +183,6 @@ References
 .. |CodeClimate| image:: https://api.codeclimate.com/v1/badges/fc83491ef0ae81080882/maintainability
                  :target: https://codeclimate.com/github/hthiery/python-fritzhome/maintainability
                  :alt: Maintainability
-.. |Codacy|      image:: https://api.codacy.com/project/badge/Grade/0929296afb8c45c6af673524fe232d9e
-                 :target: https://www.codacy.com/app/hthiery/python-fritzhome?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=hthiery/python-fritzhome&amp;utm_campaign=Badge_Grade
 
 .. _Comet DECT: https://www.eurotronic.org/produkte/comet-dect.html
 .. _FRITZ!DECT 200: https://avm.de/produkte/fritzdect/fritzdect-200/


### PR DESCRIPTION
This fixes warnings in the action runs:

`The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, actions/setup-python@v4, coverallsapp/github-action@master. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/`