### PR TITLE
powermeter: catch invalid values for power and energy

### DIFF
--- a/pyfritzhome/devicetypes/fritzhomedevicepowermeter.py
+++ b/pyfritzhome/devicetypes/fritzhomedevicepowermeter.py
@@ -34,8 +34,17 @@ class FritzhomeDevicePowermeter(FritzhomeDeviceBase):
     def _update_powermeter_from_node(self, node):
         _LOGGER.debug("update powermeter device")
         val = node.find("powermeter")
-        self.power = int(val.findtext("power"))
-        self.energy = int(val.findtext("energy"))
+
+        try:
+            self.power = int(val.findtext("power"))
+        except Exception:
+            pass
+
+        try:
+            self.energy = int(val.findtext("energy"))
+        except Exception:
+            pass
+
         try:
             self.voltage = int(val.findtext("voltage"))
         except Exception:

--- a/tests/responses/powermeter/device_list_faulty.xml
+++ b/tests/responses/powermeter/device_list_faulty.xml
@@ -10,9 +10,6 @@
             <devicelock>0</devicelock>
         </switch>
         <powermeter>
-            <power>0</power>
-            <energy>0</energy>
-            <voltage>0</voltage>
         </powermeter>
         <temperature>
             <celsius>285</celsius>

--- a/tests/test_fritzhomedevicepowermeter.py
+++ b/tests/test_fritzhomedevicepowermeter.py
@@ -74,7 +74,7 @@ class TestFritzhomeDevicePowermeter(object):
         self.fritz.update_devices()
         device = self.fritz.get_device_by_ain("08761 0000434")
 
-        assert device.energy == 0
-        assert device.power == 0
-        assert device.voltage == 0
+        assert device.energy is None
+        assert device.power is None
+        assert device.voltage is None
         assert device.current is None


### PR DESCRIPTION
There are devices that can return empty values for these fields. To avoid crashing (throwing uncatched exception) we catch these.

- fixes #109