### PR TITLE
Simplify and fix set target temperature calculations

### DIFF
--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -292,7 +292,7 @@ class Fritzhome(object):
 
     def _get_temperature(self, ain, name):
         plain = self._aha_request(name, ain=ain, rf=float)
-        return (plain - 16) / 2 + 8
+        return plain / 2
 
     def get_target_temperature(self, ain):
         """Get the thermostate target temperature."""
@@ -300,11 +300,11 @@ class Fritzhome(object):
 
     def set_target_temperature(self, ain, temperature, wait=False):
         """Set the thermostate target temperature."""
-        temp = int(16 + ((float(temperature) - 8) * 2))
+        temp = int(temperature * 2)
 
-        if temp < min(range(16, 56)):
+        if temp < 16:
             temp = 253
-        elif temp > max(range(16, 56)):
+        elif temp > 56:
             temp = 254
 
         self._aha_request("sethkrtsoll", ain=ain, param={"param": temp})


### PR DESCRIPTION
`(plain - 16) / 2 + 8` - this subtracts 16 from the value, halves it and then adds the half of of 16 again - so just halve the value is the same

`int(16 + ((float(temperature) - 8) * 2))` - this subtracts 8 from the value, doubles it and add the double of 8 again - so just double the value is the same

`temp > max(range(16, 56)):` this was already `true` for `temp=56` instead of a temp higher than 56