### PR TITLE
Fix wait for txbusy for FritzOS <7.20

### DIFF
--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -221,8 +221,9 @@ class Fritzhome(object):
             if not txbusy:
                 # txbusy was added in FritzOS 7.20
                 self._has_txbusy = False
+                return True
 
-            if not txbusy or txbusy[0].text == "0":
+            if txbusy[0].text == "0":
                 return True
 
             time.sleep(0.2)

--- a/tests/responses/base/device_list_no_txbusy.xml
+++ b/tests/responses/base/device_list_no_txbusy.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<devicelist version="1">
+    <device functionbitmask="320" fwversion="03.54" id="18" identifier="32960 0089208" manufacturer="AVM" productname="Comet DECT">
+        <present>0</present>
+        <name>Kitchen</name>
+        <temperature>
+            <celsius/>
+            <offset/>
+        </temperature>
+        <hkr>
+            <tist/>
+            <tsoll/>
+            <absenk/>
+            <komfort/>
+            <lock/>
+            <devicelock/>
+            <errorcode>0</errorcode>
+            <batterylow>0</batterylow>
+            <nextchange>
+                <endperiod>0</endperiod>
+                <tchange>255</tchange>
+            </nextchange>
+        </hkr>
+    </device>
+</devicelist>

--- a/tests/test_fritzhome.py
+++ b/tests/test_fritzhome.py
@@ -355,8 +355,19 @@ class TestFritzhome(object):
             Helper.response("base/device_list_not_txbusy"),
         ]
 
+        # first call will set _has_getdeviceinfos to False
+        # so sub-sequent calls won't try getdeviceinfos anymore
         assert self.fritz.wait_device_txbusy("22960 0089208")
         assert self.mock.call_count == 3
+
+        self.mock.reset_mock()
+        self.mock.side_effect = [
+            Helper.response("base/device_list_txbusy"),
+            Helper.response("base/device_list_not_txbusy"),
+        ]
+
+        assert self.fritz.wait_device_txbusy("22960 0089208")
+        assert self.mock.call_count == 2
 
     def test_wait_tx_busy_no_txbusy(self):
         """FritzOS <7.20 has no txbusy and no getdeviceinfos"""
@@ -365,8 +376,13 @@ class TestFritzhome(object):
             Helper.response("base/device_list_no_txbusy"),
         ]
 
+        # first call will set _has_txbusy to False, those skip all sub-sequent calls
         assert self.fritz.wait_device_txbusy("32960 0089208")
         assert self.mock.call_count == 2
+        self.mock.reset_mock()
+
+        assert self.fritz.wait_device_txbusy("32960 0089208")
+        assert self.mock.call_count == 0
 
     def test_wait_tx_busy_failed(self):
         self.mock.side_effect = [

--- a/tests/test_fritzhome.py
+++ b/tests/test_fritzhome.py
@@ -345,8 +345,10 @@ class TestFritzhome(object):
         ]
 
         assert self.fritz.wait_device_txbusy("11960 0089208")
+        assert self.mock.call_count == 2
 
     def test_wait_tx_busy_fallback(self):
+        """FritzOS <7.24 has no getdeviceinfos"""
         self.mock.side_effect = [
             HTTPError("400 Client Error: Bad Request"),
             Helper.response("base/device_list_txbusy"),
@@ -354,6 +356,17 @@ class TestFritzhome(object):
         ]
 
         assert self.fritz.wait_device_txbusy("22960 0089208")
+        assert self.mock.call_count == 3
+
+    def test_wait_tx_busy_no_txbusy(self):
+        """FritzOS <7.20 has no txbusy and no getdeviceinfos"""
+        self.mock.side_effect = [
+            HTTPError("400 Client Error: Bad Request"),
+            Helper.response("base/device_list_no_txbusy"),
+        ]
+
+        assert self.fritz.wait_device_txbusy("32960 0089208")
+        assert self.mock.call_count == 2
 
     def test_wait_tx_busy_failed(self):
         self.mock.side_effect = [
@@ -362,3 +375,4 @@ class TestFritzhome(object):
         ]
 
         assert not self.fritz.wait_device_txbusy("11960 0089208", 1)
+        assert self.mock.call_count == 1


### PR DESCRIPTION
`getdeviceinfos` has been added in FritzOS 7.24
`txbusy`  has been added in FritzOS 7.20

So when `txbusy` is not present, we can skip `wait_device_txbusy` at all, but if it is present, we need to check if `getdeviceinfos` is available or fallback to `getdevicelistinfos`

- fixes #115