### PR TITLE
Drop ubuntu-20.04 Runner images and setup using pip

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         run: pydocstyle
 
       - name: Setup
-        run: python setup.py install
+        run: pip install .
 
       - name: Test
         run: pytest --cov=pyfritzhome --cov-report=lcov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         include:
           - python-version: "3.7"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - python-version: "3.8"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - python-version: "3.9"
             os: ubuntu-latest
           - python-version: "3.10"


### PR DESCRIPTION
- `ubuntu-20.04` is deprecated, see https://github.com/actions/runner-images/issues/11101
- calling `setup.py install` is also deprecated:
```
        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************
```