### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python 3.9
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
       - name: Install pypa/build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,10 @@ jobs:
             os: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Update github actions:

- [checkout@v5](https://github.com/actions/checkout/releases/tag/v5.0.0)
- [setup-python@v6](https://github.com/actions/setup-python/releases/tag/v6.0.0)

Both update the used node version from  `20` to `24` as node 20 is deprecated on github action runners: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/