### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.7"
-            os: ubuntu-22.04
-          - python-version: "3.8"
-            os: ubuntu-22.04
           - python-version: "3.9"
             os: ubuntu-latest
           - python-version: "3.10"
@@ -23,6 +19,8 @@ jobs:
           - python-version: "3.12"
             os: ubuntu-latest
           - python-version: "3.13"
+            os: ubuntu-latest
+          - python-version: "3.14"
             os: ubuntu-latest
           - python-version: "pypy3.9"
             os: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,11 +35,11 @@ jobs:
 
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
-        run: pip install pytest pytest-cov python-coveralls coverage flake8 pydocstyle setuptools cryptography<44
+        run: pip install pytest pytest-cov python-coveralls coverage flake8 pydocstyle cryptography<44
 
       - name: Install dependencies (Ubuntu)
         if: runner.os == 'Linux'
-        run: pip install pytest pytest-cov python-coveralls coverage flake8 pydocstyle setuptools cryptography
+        run: pip install pytest pytest-cov python-coveralls coverage flake8 pydocstyle cryptography
 
       - name: Lint with flake8
         run: |

--- a/README.rst
+++ b/README.rst
@@ -167,7 +167,7 @@ Add a new user: System -> FRITZ!Box-Benutzer
 References
 ----------
 
-- https://avm.de/fileadmin/user_upload/Global/Service/Schnittstellen/AHA-HTTP-Interface.pdf
+- https://fritz.support/resources/AHA-HTTP-Interface.pdf
 - https://github.com/DerMitch/fritzbox-smarthome
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,13 +13,12 @@ license_file = LICENSE
 classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ classifiers =
 packages = find:
 include_package_data = true
 test_suite = tests
-setup_requires = setuptools
 install_requires = requests; cryptography
 tests_requires = pytest
 


### PR DESCRIPTION
- Add Python 3.14 to supported versions
- Drop Python 3.7, its EOL since about two years; Python 3.8 is EOL since about one year.
- Python 3.9 just dropped out of support, keep it for now
- Remove `setuptools` from dependencies, it is not needed anymore since #120 
- Update link to FRITZ! API documentation