### PR TITLE
Fix set_target_temperature() when called with 126.5

### DIFF
--- a/pyfritzhome/fritzhome.py
+++ b/pyfritzhome/fritzhome.py
@@ -306,7 +306,7 @@ class Fritzhome(object):
 
         if temp < 16:
             temp = 253
-        elif temp > 56:
+        elif temp > 56 and not temp == 253:
             temp = 254
 
         self._aha_request("sethkrtsoll", ain=ain, param={"param": temp})


### PR DESCRIPTION
This happens if any of the preset modes eco or comfort are set to off in the Fritzbox UI for a thermostat, e.g. the 302.

Fixes #129.

Luckily 126.5 has an exact binary representation as floating point number ...